### PR TITLE
Show duplicate username registration error

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
@@ -110,9 +110,18 @@
                 } else {
                     [self registrationSuccess:user];
                 }
+            } else if (status == kOTMAPILoginDuplicateUsername) {
+                [self.username becomeFirstResponder];
+                [self.username selectAll:self];
+                NSString *message = [NSString stringWithFormat:@"The username %@ is already reistered. Tap 'Login' and enter your password for this username or choose a different username.", self.username.text];
+                [[[UIAlertView alloc] initWithTitle:@"Already Registered"
+                                            message:message
+                                           delegate:nil
+                                  cancelButtonTitle:@"OK"
+                                  otherButtonTitles:nil] show];
             } else {
-                [[[UIAlertView alloc] initWithTitle:@"Server Error"
-                                           message:@"There was a server error"
+                [[[UIAlertView alloc] initWithTitle:@"Registration Failed"
+                                           message:@"A server problem prevented your registration from completing. Please try again later."
                                           delegate:nil
                                  cancelButtonTitle:@"OK"
                                   otherButtonTitles:nil] show];

--- a/OpenTreeMap/src/OTM/OTMAPI.m
+++ b/OpenTreeMap/src/OTM/OTMAPI.m
@@ -261,7 +261,13 @@
     {
         if (callback != nil) {
             if (error != nil) {
-               callback(user, kOTMAPILoginResponseError);
+                NSDictionary *info = [error userInfo];
+                NSNumber *statusCode = [info objectForKey:@"statusCode"];
+                if (statusCode && [statusCode intValue] == 409) {
+                    callback(user, kOTMAPILoginDuplicateUsername);
+                } else {
+                    callback(user, kOTMAPILoginResponseError);
+                }
             } else {
                 if ([[json objectForKey:@"status"] isEqualToString:@"success"]) {
                     user.userId = [[json valueForKey:@"id"] intValue];


### PR DESCRIPTION
As of OpenTreeMap commit 0fa82a6f1 the api will return a
409 Confilct if you attempt to POST and existing username
to /user. I added a check for the 409 status code, show an
appropriate message, then select the text in the username
field.
