### PR TITLE
Use JPEG compression for tree photos

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -128,14 +128,6 @@
     [pictureTaker getPictureInViewController:self
                                     callback:^(UIImage *image)
      {
-         CGFloat aspect = image.size.height / image.size.width;
-         CGFloat newWidth = 800.0;
-         CGFloat newHeight = aspect * newWidth;
-         UIGraphicsBeginImageContextWithOptions(CGSizeMake(newWidth, newHeight), YES, 0.0);
-         [image drawInRect:CGRectMake(0, 0, newWidth, newHeight)];
-         image = UIGraphicsGetImageFromCurrentImageContext();
-         UIGraphicsEndImageContext();
-         
          self.imageView.image = image;
 
          NSMutableDictionary *tree = [[self data] objectForKey:@"tree"];

--- a/OpenTreeMap/src/OTM/OTMAPI.m
+++ b/OpenTreeMap/src/OTM/OTMAPI.m
@@ -248,8 +248,8 @@
          withUser:user
            params:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:pId]
                                               forKey:@"plot_id"]
-             data:UIImagePNGRepresentation(image) 
-      contentType:@"image/png"
+             data:UIImageJPEGRepresentation(image, 0.2) // JPEG compression level is 0.0 to 1.0 with 1.0 being no compression, so 0.2 is 80% compression.
+      contentType:@"image/jpeg"
          callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:cb]]];    
 }
 


### PR DESCRIPTION
The PNG representation was creating 1.7 MB files for an 800x1100 image. A full size (2448 × 3264) 80% JPEG compressed image is only 400k.
