### PR TITLE
Add in new filter type for choices-based lists

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
@@ -15,6 +15,7 @@
 
 #import <UIKit/UIKit.h>
 #import "OTMScrollAwareViewController.h"
+#import "OTMButton.h"
 
 typedef enum {
     kOTMFiltersShowAll = 0,
@@ -48,6 +49,7 @@ typedef enum {
 #define OTMFilterKeyType @"OTMFilterKeyType"
 #define OTMFilterKeyName @"OTMFilterKeyName"
 #define OTMFilterKeyKey  @"OTMFilterKeyKey"
+#define OTMChoiceFilterChoiceKey @"OTMChoiceFilterChoice"
 
 @interface OTMFilter : NSObject
 
@@ -95,6 +97,18 @@ typedef enum {
 - (id)initWithName:(NSString *)nm key:(NSString *)k;
 
 @end
+
+@interface OTMChoiceFilter : OTMFilter
+
+@property (nonatomic,readonly) OTMButton *button;
+@property (nonatomic,readonly) UITableViewController *tvc;
+@property (nonatomic,readonly) NSDictionary *selectedChoice;
+@property (nonatomic,readonly) NSArray *allChoices;
+
+- (id)initWithName:(NSString *)nm key:(NSString *)k choiceKey:(NSString *)ck;
+
+@end
+
 
 
 @interface OTMFilterListViewController : OTMScrollAwareViewController


### PR DESCRIPTION
Previously we just had generic "Boolean" and "Range" filters.
This commit adds a new filter type:
  OTMChoiceFilter

If the filter type is selected the dictionary should also
provide a "OTMChoiceFilterChoice" key with the name of the
choice field that they wish to filter filter on.

A complete filter definition looks something like this:

``` xml
<key>OTMFilterKeyKey</key>
<string>filter_pests</string>
<key>OTMFilterKeyName</key>
<string>Pests</string>
<key>OTMFilterKeyType</key>
<string>OTMChoiceFilter</string>
<key>OTMChoiceFilterChoice</key>
<string>pests</string>
```
