### PR TITLE
Don't allow users to edit readonly trees

### DIFF
--- a/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
+++ b/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="1.1" toolsVersion="2182" systemVersion="11G63" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="7zY-vH-TMB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="2843" systemVersion="11E53" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="7zY-vH-TMB">
     <dependencies>
-        <deployment defaultVersion="1296" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="1181"/>
+        <deployment defaultVersion="1536" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="1929"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller - Tree Map-->
@@ -398,7 +398,7 @@
             <objects>
                 <tableViewController id="v8c-v7-6H5" customClass="OTMSpeciesTableViewController" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="vV2-mt-eHo">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="367"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="Xap-fy-aIY">
@@ -469,7 +469,6 @@
         <!--Splash View Controller-->
         <scene sceneID="Bnb-dg-gfO">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="MKb-h0-uZc" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <viewController id="7zY-vH-TMB" customClass="OTMSplashViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="K5g-s6-br4">
                         <rect key="frame" x="0.0" y="20" width="320" height="460"/>
@@ -486,6 +485,7 @@
                         <segue destination="4" kind="custom" identifier="startApp" customClass="OTMSwapSegue" id="hNa-Ed-G3s"/>
                     </connections>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MKb-h0-uZc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-412" y="180"/>
         </scene>
@@ -870,7 +870,7 @@
         <simulatedScreenMetrics key="destination"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="145-jK-ChU"/>
         <segue reference="l7d-z8-dsy"/>
+        <segue reference="Lek-fL-nUD"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/OpenTreeMap/src/OTM/OTMAPI.h
+++ b/OpenTreeMap/src/OTM/OTMAPI.h
@@ -11,7 +11,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with OpenTreeMap.  If not, see <http://www.gnu.org/licenses/>.   
+// along with OpenTreeMap.  If not, see <http://www.gnu.org/licenses/>.
 
 #import <Foundation/Foundation.h>
 #import <MapKit/MapKit.h>
@@ -78,7 +78,7 @@ typedef void(^AZUserCallback)(OTMUser* user, OTMAPILoginResponse status);
 -(void)getPlotsNearLatitude:(double)lat longitude:(double)lon user:(OTMUser *)user callback:(AZJSONCallback)callback;
 -(void)getPlotsNearLatitude:(double)lat longitude:(double)lon user:(OTMUser *)user filters:(OTMFilters *)filters callback:(AZJSONCallback)callback;
 -(void)getPlotsNearLatitude:(double)lat longitude:(double)lon user:(OTMUser *)user maxResults:(NSUInteger)max filters:(OTMFilters *)filters distance:(double)distance callback:(AZJSONCallback)callback;
- 
+
 /**
  * Request an image for a given tree/plot
  *
@@ -217,6 +217,14 @@ typedef void(^AZUserCallback)(OTMUser* user, OTMAPILoginResponse status);
  * @param callback block to be executed when the request is complete or an error occurs
  */
 -(void)deleteTreeFromPlot:(NSInteger)plotId user:(OTMUser *)user callback:(AZJSONCallback)callback;
+
+/**
+ * Get updated edit info based on user login info
+ * @param plotId the ID of a plot to get info about
+ * @param user the authenticated user who wants this info
+ * @param callback block to be executed when the request is complete or an error occurs
+ */
+-(void)getPlotInfo:(NSInteger)plotId user:(OTMUser *)user callback:(AZJSONCallback)callback;
 
 /**
  * Delete a plot

--- a/OpenTreeMap/src/OTM/OTMAPI.m
+++ b/OpenTreeMap/src/OTM/OTMAPI.m
@@ -11,7 +11,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with OpenTreeMap.  If not, see <http://www.gnu.org/licenses/>.   
+// along with OpenTreeMap.  If not, see <http://www.gnu.org/licenses/>.
 
 #import "OTMAPI.h"
 #import "ASIHTTPRequest.h"
@@ -56,10 +56,10 @@
                 callback(nil, error);
             } else {
                 NSError* error = nil;
-            
+
                 id json = [NSJSONSerialization JSONObjectWithData:data
                                                           options:0
-                                                            error:&error];    
+                                                            error:&error];
                 callback(json, error);
             }
     } copy];
@@ -85,7 +85,7 @@
                          if (callback) { callback(nil, err); }
                      } else {
                          NSMutableDictionary *s = [NSMutableDictionary dictionary];
-                         
+
                          [json enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                              [s setObject:[NSDictionary dictionaryWithObjectsAndKeys:
                                               [obj objectForKey:@"id"], @"id",
@@ -96,7 +96,7 @@
                          if (callback) { callback(species, nil); }
                      }
                  }]]];
-                           
+
     }
 }
 
@@ -126,7 +126,7 @@
     if (filters != nil) {
         [params addEntriesFromDictionary:[filters filtersDict]];
     }
-    
+
     if (distance > 0) {
         [params setObject:[NSString stringWithFormat:@"%f", distance]
                    forKey:@"distance"];
@@ -140,14 +140,14 @@
 }
 
 -(void)getImageForTree:(int)plotid photoId:(int)photoid callback:(AZImageCallback)callback {
-    [self.request getRaw:@"plots/:plot/tree/photo/:photo" 
+    [self.request getRaw:@"plots/:plot/tree/photo/:photo"
                   params:[NSDictionary dictionaryWithObjectsAndKeys:
                           [NSString stringWithFormat:@"%d", plotid], @"plot",
                           [NSString stringWithFormat:@"%d", photoid], @"photo", nil]
                     mime:@"image/jpeg"
-                callback:[OTMAPI liftResponse:^(id data, NSError* error) { 
+                callback:[OTMAPI liftResponse:^(id data, NSError* error) {
                     if (callback) {
-                        if (error != nil) { 
+                        if (error != nil) {
                             callback(nil, error);
                         } else {
                             callback([UIImage imageWithData:data], nil);
@@ -158,19 +158,19 @@
 
 -(void)savePlot:(NSDictionary *)plot withUser:(OTMUser *)user callback:(AZJSONCallback)callback {
     id pId = [plot objectForKey:@"id"];
-    
+
     // Update (PUT)
     if (pId != nil) {
-        
+
     } else {
         // POST
     }
 }
 
 -(void)logUserIn:(OTMUser*)user callback:(AZUserCallback)callback {
-    [request get:@"login" 
-        withUser:user 
-          params:nil 
+    [request get:@"login"
+        withUser:user
+          params:nil
         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:^(id json, NSError* error) {
         if (error) {
             [user setLoggedIn:NO];
@@ -193,7 +193,7 @@
             callback(user, kOTMAPILoginResponseOK);
         }
     }]]];
-    
+
 }
 
 -(void)getProfileForUser:(OTMUser *)user callback:(AZJSONCallback)callback {
@@ -208,7 +208,7 @@
            params:[NSDictionary dictionaryWithObject:email forKey:@"email"]
              data:nil
          callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:callback]]];
-        
+
 }
 
 -(NSData *)encodeUser:(OTMUser *)user {
@@ -219,7 +219,7 @@
     [userDict setObject:user.email forKey:@"email"];
     [userDict setObject:user.password forKey:@"password"];
     [userDict setObject:user.zipcode forKey:@"zipcode"];
-    
+
     return [self jsonEncode:userDict];
 }
 
@@ -229,7 +229,7 @@
     if (error != NULL) {
         NSLog(@"[ERROR] Could not encode \"%@\" as json (error: %@)",obj,error);
     }
-    
+
     return jsonData;
 }
 
@@ -238,7 +238,7 @@
          withUser:user
            params:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:user.userId]
                                               forKey:@"user_id"]
-             data:UIImagePNGRepresentation(user.photo) 
+             data:UIImagePNGRepresentation(user.photo)
       contentType:@"image/png"
          callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:callback]]];
 }
@@ -250,14 +250,14 @@
                                               forKey:@"plot_id"]
              data:UIImageJPEGRepresentation(image, 0.2) // JPEG compression level is 0.0 to 1.0 with 1.0 being no compression, so 0.2 is 80% compression.
       contentType:@"image/jpeg"
-         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:cb]]];    
+         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:cb]]];
 }
 
 -(void)createUser:(OTMUser *)user callback:(AZUserCallback)callback {
     [request post:@"user/"
            params:nil
              data:[self encodeUser:user]
-         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:^(NSDictionary *json, NSError *error) 
+         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:^(NSDictionary *json, NSError *error)
     {
         if (callback != nil) {
             if (error != nil) {
@@ -286,8 +286,8 @@
           params:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:user.userId]
                                              forKey:@"user_id"]
             data:[self jsonEncode:[NSDictionary dictionaryWithObject:newPass forKey:@"password"]]
-        callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:^(NSDictionary *json, NSError *error) 
-        {        
+        callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:^(NSDictionary *json, NSError *error)
+        {
             if (callback != nil) {
                 if (error != nil) {
                     callback(user, kOTMAPILoginResponseError);
@@ -301,7 +301,7 @@
                 }
             }
         }]]];
-        
+
 }
 
 -(void)getRecentActionsForUser:(OTMUser *)user callback:(AZJSONCallback)callback {
@@ -319,7 +319,7 @@
                   dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:user.userId],
                                                 @"user_id",
                                                 [NSNumber numberWithInt:offset],
-                                                @"offset", 
+                                                @"offset",
                                                 [NSNumber numberWithInt:length],
                                                 @"length", nil]
         callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:callback]]];
@@ -457,5 +457,13 @@
              params:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:plotId] forKey:@"id"]
            callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:callback]]];
 }
+
+-(void)getPlotInfo:(NSInteger)plotId user:(OTMUser *)user callback:(AZJSONCallback)callback {
+  [request get:@"plots/:id"
+      withUser:user
+        params:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:plotId] forKey:@"id"]
+      callback:[OTMAPI liftResponse:[OTMAPI jsonCallback:callback]]];
+}
+
 
 @end


### PR DESCRIPTION
OTM supports a 'readonly' flag which is exposed by the api as
"perm.plot.can_edit", however OTM-iOS was ignoring this flag.

Now we disable the edit button if the flag is set. We also force a
tree/plot update when the user logs in (since the default is that they
can't really edit anything).

Also, cleanup white space. Sorry for the crappy diff!
