### PR TITLE
Allow users to make new trees (fixes 056bc12e4cd8)

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -612,7 +612,12 @@
 }
 
 - (BOOL)canEditThing:(NSString *)thing {
-    return [[[[data objectForKey:@"perm"] objectForKey:thing] objectForKey:@"can_delete"] intValue] == 1;
+    NSDictionary *perms = [data objectForKey:@"perm"];
+    if (perms) {
+        return [[[perms objectForKey:thing] objectForKey:@"can_edit"] intValue] == 1;
+    } else { // If there aren't specific permissions, allow it
+        return YES;
+    }
 }
 
 - (BOOL)canEditEitherPlotOrTree {


### PR DESCRIPTION
Commit 056bc12e4cd8 added support for readonly trees by looking at the
"can_edit" property. When a new tree is added it doesn't have a set of
permissions from the API so "can_edit" was essentially returning nil.

Now we only prevent editing if the API explicitly returns a permission
set.
