### PR TITLE
Allow editing if no permission data given

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -629,7 +629,7 @@
 
 - (BOOL)canEditThing:(NSString *)thing {
     NSDictionary *perms = [data objectForKey:@"perm"];
-    if (perms) {
+    if (perms && [perms objectForKey:thing]) {
         return [[[perms objectForKey:thing] objectForKey:@"can_edit"] intValue] == 1;
     } else { // If there aren't specific permissions, allow it
         return YES;


### PR DESCRIPTION
Previously we did this by checking the "perms" section of the tree data.
If that section didn't exist we assumed they had editing power.

If a person only creates a plot the perms section will exist but wont
contain any information about the tree. This commit now assumes that
missing tree or plot information should be treated as 'edit allowed'
