### PR TITLE
Show eco benefits on the detail page

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
@@ -95,6 +95,9 @@ ABSTRACT_METHOD
 @interface OTMBenefitsDetailCellRenderer : OTMDetailCellRenderer
 
 @property (nonatomic,strong) OTMBenefitsTableViewCell *cell;
+@property (nonatomic,assign) NSInteger *index;
+
+-(id)initWithLabel:(NSString *)label index:(NSInteger) idx;
 
 @end
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -114,24 +114,25 @@
 @implementation OTMBenefitsDetailCellRenderer
 
 
--(id)initWithDataKey:(NSString *)datakey label:(NSString *)label {
-    self = [super initWithDataKey:datakey];
+-(id)initWithLabel:(NSString *)label index:(NSInteger)idx {
+    self = [super initWithDataKey:nil];
 
     if (self) {
         _cell = [OTMBenefitsTableViewCell loadFromNib];
         self.cellHeight = _cell.frame.size.height;
         self.cell.benefitName.text = label;
+        self.index = idx;
     }
 
     return self;
 }
 
 -(UITableViewCell *)prepareCell:(NSDictionary *)data inTable:(UITableView *)tableView {
-
-    NSString *num = [data decodeKey:self.dataKey];
-    self.cell.benefitValue.text = num;
-    self.cell.benefitDollarAmt.text = num;
-
+    NSDictionary* benefit = [[data objectForKey:@"benefits"] objectAtIndex:self.index];
+    NSString* value = [benefit objectForKey:@"value"];
+    NSString* unit = [benefit objectForKey:@"unit"];
+    self.cell.benefitValue.text = [NSString stringWithFormat:@"%@ %@", value, unit];
+    self.cell.benefitDollarAmt.text = [NSString stringWithFormat:@"%@ saved", [benefit objectForKey:@"currency_saved"]];
     return _cell;
 }
 

--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -197,6 +197,7 @@
         id keys = [[OTMEnvironment sharedEnvironment] fieldKeys];
 
         dest.keys = keys;
+        dest.ecoKeys = [[OTMEnvironment sharedEnvironment] ecoFields];
         dest.imageView.image = self.treeImage.image;
         if (self.mode != Select) {
             // When adding a new tree the detail view is automatically in edit mode

--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.h
@@ -81,6 +81,14 @@
  */
 @property (nonatomic, strong) NSArray* keys;
 
+/**
+ * Array[OTMDetailCellRenderer] ecoKeys to display in the main table
+ *
+ * Each element in the array is a field for displaying a single eco
+ * benefit in a table row
+ */
+@property (nonatomic, strong) NSArray* ecoKeys;
+
 - (IBAction)showTreePhotoFullscreen:(id)sender;
 - (IBAction)startOrCommitEditing:(id)sender;
 - (IBAction)cancelEditing:(id)sender;

--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -231,6 +231,19 @@
     self.navigationItem.rightBarButtonItem.enabled = [self canEditBothPlotAndTree];
 }
 
+- (void)setEcoKeys:(NSArray *)ecoKeys {
+    NSUInteger startingIndex = [allFields count];
+    for (int section=0; section < [ecoKeys count]; section ++) {
+        NSMutableArray *ecoFieldRenderers = [[NSMutableArray alloc] init];
+        NSArray *ecoFields = [ecoKeys objectAtIndex:section];
+        for (int row=0; row < [ecoFields count]; row++) {
+            [ecoFieldRenderers addObject:[ecoFields objectAtIndex:row]];
+            [(NSMutableArray*)txToEditRemove addObject:[NSIndexPath indexPathForRow:row inSection:startingIndex + section]];
+        }
+        [(NSMutableArray*)allFields addObject:ecoFieldRenderers];
+    }
+}
+
 - (IBAction)showTreePhotoFullscreen:(id)sender {
     NSArray *images = [[self.data objectForKey:@"tree"] objectForKey:@"images"];
     NSString* imageURL = [[images objectAtIndex:0] objectForKey:@"url"];
@@ -312,6 +325,9 @@
         [self.tableView deleteRowsAtIndexPaths:txToEditRemove
                               withRowAnimation:UITableViewRowAnimationFade];
 
+        // Remove the eco section, which is appended to the end and never editable
+        [self.tableView deleteSections:[NSIndexSet indexSetWithIndex:[allFields count]-1] withRowAnimation:UITableViewRowAnimationFade];
+
         // There are 2 fixed sections to be added when editing: the mini map section and the species/photo section
         [self.tableView insertSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]
                       withRowAnimation:UITableViewRowAnimationFade];
@@ -343,6 +359,10 @@
 
         // There are 2 fixed sections to be removed after editing: the mini map section and the species/photo section
         [self.tableView deleteSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]
+                      withRowAnimation:UITableViewRowAnimationFade];
+
+        // Resore the eco section which was removed during editing. It is always the last section
+        [self.tableView insertSections:[NSIndexSet indexSetWithIndex:[allFields count]-1]
                       withRowAnimation:UITableViewRowAnimationFade];
 
         [self.tableView insertRowsAtIndexPaths:txToEditRemove

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -96,6 +96,7 @@
 @property (nonatomic, assign) BOOL pendingActive;
 @property (nonatomic, strong) NSArray* fieldSections;
 @property (nonatomic, strong) NSArray* fields;
+@property (nonatomic, strong) NSArray* ecoFields;
 @property (nonatomic, strong) NSArray* filts;
 @property (nonatomic, assign) BOOL useOtmGeocoder;
 @property (nonatomic, assign) double searchRegionRadiusInMeters;

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -168,6 +168,7 @@
 
     self.filters = [regFilters arrayByAddingObjectsFromArray:missingFilters];
 
+    self.ecoFields = [self ecoFieldsFromDict:[dict objectForKey:@"eco"]];
     NSDictionary* center = [dict objectForKey:@"center"];
 
     CGFloat lat = [[center objectForKey:@"lat"] floatValue];
@@ -350,6 +351,24 @@
     }];
 
     return fieldArray;
+}
+
+- (NSArray*)ecoFieldsFromDict:(NSDictionary*)ecoDict {
+    if ([ecoDict objectForKey:@"supportsEcoBenefits"]) {
+        NSMutableArray *fieldArray = [NSMutableArray array];
+        NSArray *benefits = [ecoDict objectForKey:@"benefits"];
+        [benefits enumerateObjectsUsingBlock:^(NSDictionary *fieldDict, NSUInteger idx, BOOL *stop) {
+            // Currently, we create the same type of cell renderer without regard to
+            // any of the field details
+            [fieldArray addObject:[[OTMBenefitsDetailCellRenderer alloc] initWithLabel:[fieldDict objectForKey:@"label"] index:idx]];
+        }];
+        // To be consistant with the editable fields, the eco fields are wrapped in a containing
+        // array that represents the field group. This may be useful
+        // in the future when there may be multiple sets of eco benefits.
+        return [NSArray arrayWithObject:fieldArray];
+    } else {
+        return [[NSArray alloc] init];
+    }
 }
 
 @end


### PR DESCRIPTION
Eco benefit fields used to be mixed in with the regular fields. Because they are read only and never have permission control, it makes sense to keep them separate when handling them.
