### PR TITLE
Show empty eco cell rather than "null"

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -128,11 +128,21 @@
 }
 
 -(UITableViewCell *)prepareCell:(NSDictionary *)data inTable:(UITableView *)tableView {
-    NSDictionary* benefit = [[data objectForKey:@"benefits"] objectAtIndex:self.index];
-    NSString* value = [benefit objectForKey:@"value"];
-    NSString* unit = [benefit objectForKey:@"unit"];
-    self.cell.benefitValue.text = [NSString stringWithFormat:@"%@ %@", value, unit];
-    self.cell.benefitDollarAmt.text = [NSString stringWithFormat:@"%@ saved", [benefit objectForKey:@"currency_saved"]];
+    NSDictionary *benefit = [[data objectForKey:@"benefits"] objectAtIndex:self.index];
+
+    NSString *value = [benefit objectForKey:@"value"];
+    NSString *unit = [benefit objectForKey:@"unit"];
+    if (value) {
+        self.cell.benefitValue.text = [NSString stringWithFormat:@"%@ %@", value, unit];
+    } else {
+        self.cell.benefitValue.text = @"";
+    }
+
+    if ([benefit objectForKey:@"currency_saved"]) {
+        self.cell.benefitDollarAmt.text = [NSString stringWithFormat:@"%@ saved", [benefit objectForKey:@"currency_saved"]];
+    } else {
+        self.cell.benefitDollarAmt.text = @"";
+    }
     return _cell;
 }
 


### PR DESCRIPTION
When there is no eco value to show, the cell should be empty rather than
displaying "null".

I also fixed the variable declarations to use idomatic Objective-C style.
