### PR TITLE
Load branding preferences from API endpoint

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -103,6 +103,11 @@
                                                  name:kOTMChangeMapModeNotification
                                                object:nil];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(changeEnvironment:)
+                                                 name:kOTMEnvironmentChangeNotification
+                                               object:nil];
+
     [super viewDidLoad];
     [self slideDetailDownAnimated:NO];
     [self slideAddTreeHelpDownAnimated:NO];
@@ -123,6 +128,10 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                  name:kOTMChangeMapModeNotification
                                                object:nil];
+
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:kOTMEnvironmentChangeNotification
+                                                  object:nil];
 }
 
 -(void)updatedImage:(NSNotification *)note {
@@ -131,7 +140,7 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    [self.tabBarController.tabBar setSelectedImageTintColor:[[OTMEnvironment sharedEnvironment] navBarTintColor]];
+    [self.tabBarController.tabBar setSelectedImageTintColor:[[OTMEnvironment sharedEnvironment] primaryColor]];
 
     self.addTreeHelpLabel.textColor = [UIColor whiteColor];
     self.addTreeHelpLabel.shadowColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.5];
@@ -258,6 +267,11 @@
 -(void)changeMapMode:(NSNotification *)note {
     mapModeSegmentedControl.selectedSegmentIndex = [note.object intValue];
     self.mapView.mapType = (MKMapType)[note.object intValue];
+}
+
+-(void)changeEnvironment:(NSNotification *)note {
+    OTMEnvironment *env = note.object;
+    [self.tabBarController.tabBar setSelectedImageTintColor:[env primaryColor]];
 }
 
 #pragma mark Detail View

--- a/OpenTreeMap/src/OTM/OTMAppDelegate.m
+++ b/OpenTreeMap/src/OTM/OTMAppDelegate.m
@@ -30,14 +30,17 @@
 {
     keychain = [[AZKeychainItemWrapper alloc] initWithIdentifier:@"org.otm.creds"
                                                      accessGroup:nil];
-    
+
     loginManager = [[OTMLoginManager alloc] init];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeMapMode:) name:kOTMChangeMapModeNotification object:nil];
+
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeEnvironment:) name:kOTMEnvironmentChangeNotification object:nil];
 
     return YES;
 }
-							
+
 - (void)applicationWillResignActive:(UIApplication *)application
 {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
@@ -46,7 +49,7 @@
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
 }
 
@@ -70,6 +73,11 @@
 
 -(void)changeMapMode:(NSNotification *)note {
     self.mapMode = [note.object intValue];
+}
+
+-(void)changeEnvironment:(NSNotification *)note {
+    OTMEnvironment *env = note.object;
+    self.window.tintColor = env.primaryColor;
 }
 
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -19,6 +19,8 @@
 #import "OTM2API.h"
 #import "OTMFormatter.h"
 
+#define kOTMEnvironmentChangeNotification @"kOTMEnvironmentChangeNotification"
+
 /**
  An interface to global application settings that may change for each build configuration (i.e. Debug, Release)
  */
@@ -88,8 +90,9 @@
 @property (nonatomic, strong) NSArray *filters;
 
 @property (nonatomic, strong) NSArray *fieldKeys;
+@property (nonatomic, strong) UIColor *primaryColor;
+@property (nonatomic, strong) UIColor *secondaryColor;
 @property (nonatomic, strong) UIColor *viewBackgroundColor;
-@property (nonatomic, strong) UIColor *navBarTintColor;
 @property (nonatomic, strong) UIImage *buttonImage;
 @property (nonatomic, strong) UIColor *buttonTextColor;
 @property (nonatomic, assign) BOOL pendingActive;
@@ -122,6 +125,8 @@
 @property (nonatomic, strong) NSString* geoRev;
 @property (nonatomic, strong) NSString* host;
 @property (nonatomic, strong) OTMFormatter* dbhFormat;
+@property (nonatomic, strong) NSDictionary* config;
+@property (nonatomic, strong) NSURL *instanceLogoUrl;
 
 // Security
 @property (nonatomic, strong) NSString *secretKey;

--- a/OpenTreeMap/src/OTM/Theme/OTMNavigationBar.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMNavigationBar.m
@@ -20,23 +20,34 @@
 -(id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
     return self;
 }
 
 -(id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
+    return self;
+}
+
+-(id)setup {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeEnvironment:) name:kOTMEnvironmentChangeNotification object:nil];
+
+    [self loadTheme];
     return self;
 }
 
 -(void)loadTheme {
-    [self setTintColor:[[OTMEnvironment sharedEnvironment] navBarTintColor]];
+    [self setTintColor:[[OTMEnvironment sharedEnvironment] primaryColor]];
+}
+
+-(void)changeEnvironment:(NSNotification *)note {
+    [self loadTheme];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMSearchBar.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMSearchBar.m
@@ -20,23 +20,36 @@
 -(id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
     return self;
 }
 
 -(id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
     return self;
 }
 
+-(id)setup {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeEnvironment:) name:kOTMEnvironmentChangeNotification object:nil];
+
+    [self loadTheme];
+    return self;
+}
+
+
 -(void)loadTheme {
-    [self setTintColor:[[OTMEnvironment sharedEnvironment] navBarTintColor]];
+    [self setTintColor:[[OTMEnvironment sharedEnvironment] primaryColor]];
+}
+
+
+-(void)changeEnvironment:(NSNotification *)note {
+    [self loadTheme];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMSegmentedControl.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMSegmentedControl.m
@@ -20,23 +20,35 @@
 -(id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
     return self;
 }
 
 -(id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self loadTheme];
+        [self setup];
     }
-    
+
+    return self;
+}
+
+-(id)setup {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeEnvironment:) name:kOTMEnvironmentChangeNotification object:nil];
+
+    [self loadTheme];
     return self;
 }
 
 -(void)loadTheme {
-    [self setTintColor:[[OTMEnvironment sharedEnvironment] navBarTintColor]];
+    [self setTintColor:[[OTMEnvironment sharedEnvironment] primaryColor]];
+}
+
+
+-(void)changeEnvironment:(NSNotification *)note {
+    [self loadTheme];
 }
 
 @end


### PR DESCRIPTION
The instance API response now includes the "config" dictionary as well as the the custom logo url. I have added code to set these values on the environment and raise a notification that the environment changes. The various UI widgets respond to the notification and change their colors accordingly.

I removed navBarTintColor from the environment and replaced it with primaryColor (and secondary color) to avoid confusion. The color may be used for more than just nav bar tinting.
