### PR TITLE
Updating styling for iOS 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ OpenTreeMap/skin
 OpenTreeMap/Choices.plist
 OpenTreeMap/Default*.png
 OpenTreeMap/Icon*.png
-
+OpenTreeMap/Setting*.png
+OpenTreeMap/Spotlight*.png
+OpenTreeMap/iTunes*.png

--- a/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
+++ b/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		64318CD31551E27D001C827F /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C990221518C87E0094770C /* CFNetwork.framework */; };
+		6452955218D89D3400362A0F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6452955118D89D3400362A0F /* QuartzCore.framework */; };
 		64582DAE164165C200CF5DB9 /* OTMAboutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 64582DAD164165C200CF5DB9 /* OTMAboutViewController.m */; };
 		64608648160CFB0A00A1458B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 64608646160CFB0A00A1458B /* InfoPlist.strings */; };
 		6460864B160CFB2800A1458B /* OpenTreeMap-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 64608649160CFB2800A1458B /* OpenTreeMap-Info.plist */; };
@@ -78,78 +79,48 @@
 		6460872D160CFB6700A1458B /* OTMSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 646086E7160CFB6700A1458B /* OTMSegmentedControl.m */; };
 		6460872E160CFB6700A1458B /* OTMTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 646086E9160CFB6700A1458B /* OTMTableView.m */; };
 		6460872F160CFB6700A1458B /* OTMView.m in Sources */ = {isa = PBXBuildFile; fileRef = 646086EB160CFB6700A1458B /* OTMView.m */; };
-		64608782160D01A700A1458B /* about.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608739160D01A700A1458B /* about.png */; };
-		64608783160D01A700A1458B /* about@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873A160D01A700A1458B /* about@2x.png */; };
-		64608784160D01A700A1458B /* about_bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873B160D01A700A1458B /* about_bg.png */; };
-		64608785160D01A700A1458B /* about_bg@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873C160D01A700A1458B /* about_bg@2x.png */; };
-		64608786160D01A700A1458B /* add_help_bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873D160D01A700A1458B /* add_help_bg.png */; };
-		64608787160D01A700A1458B /* add_help_bg@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873E160D01A700A1458B /* add_help_bg@2x.png */; };
-		64608788160D01A700A1458B /* add_new.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460873F160D01A700A1458B /* add_new.png */; };
-		64608789160D01A700A1458B /* add_new@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608740160D01A700A1458B /* add_new@2x.png */; };
-		6460878A160D01A700A1458B /* btn_bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608741160D01A700A1458B /* btn_bg.png */; };
-		6460878B160D01A700A1458B /* btn_bg@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608742160D01A700A1458B /* btn_bg@2x.png */; };
-		6460878C160D01A700A1458B /* button_glass_red.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608743160D01A700A1458B /* button_glass_red.png */; };
-		6460878D160D01A700A1458B /* button_glass_red@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608744160D01A700A1458B /* button_glass_red@2x.png */; };
-		6460878E160D01A700A1458B /* detail.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608745160D01A700A1458B /* detail.png */; };
-		6460878F160D01A700A1458B /* filter_status_bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608746160D01A700A1458B /* filter_status_bg.png */; };
-		64608790160D01A700A1458B /* filter_status_bg@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608747160D01A700A1458B /* filter_status_bg@2x.png */; };
-		64608791160D01A700A1458B /* gps_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608748160D01A700A1458B /* gps_icon.png */; };
-		64608792160D01A700A1458B /* gps_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608749160D01A700A1458B /* gps_icon@2x.png */; };
-		64608793160D01A700A1458B /* gps_icon_14.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874A160D01A700A1458B /* gps_icon_14.png */; };
-		64608794160D01A700A1458B /* gps_icon_14@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874B160D01A700A1458B /* gps_icon_14@2x.png */; };
-		64608795160D01A700A1458B /* handle_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874C160D01A700A1458B /* handle_icon.png */; };
-		64608796160D01A700A1458B /* handle_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874D160D01A700A1458B /* handle_icon@2x.png */; };
-		64608797160D01A700A1458B /* logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874E160D01A700A1458B /* logo.png */; };
-		64608798160D01A700A1458B /* logo@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460874F160D01A700A1458B /* logo@2x.png */; };
-		64608799160D01A700A1458B /* tree_search.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608751160D01A700A1458B /* tree_search.png */; };
-		6460879A160D01A700A1458B /* tree_search_zoom1.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608752160D01A700A1458B /* tree_search_zoom1.png */; };
-		6460879B160D01A700A1458B /* tree_search_zoom3.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608753160D01A700A1458B /* tree_search_zoom3.png */; };
-		6460879C160D01A700A1458B /* tree_search_zoom5.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608754160D01A700A1458B /* tree_search_zoom5.png */; };
-		6460879D160D01A700A1458B /* tree_search_zoom6.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608755160D01A700A1458B /* tree_search_zoom6.png */; };
-		6460879E160D01A700A1458B /* tree_search_zoom7.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608756160D01A700A1458B /* tree_search_zoom7.png */; };
-		6460879F160D01A700A1458B /* tree_zoom1.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608757160D01A700A1458B /* tree_zoom1.png */; };
-		646087A0160D01A700A1458B /* tree_zoom1_highlight.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608758160D01A700A1458B /* tree_zoom1_highlight.png */; };
-		646087A1160D01A700A1458B /* tree_zoom1_plot.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608759160D01A700A1458B /* tree_zoom1_plot.png */; };
-		646087A2160D01A700A1458B /* tree_zoom3.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875A160D01A700A1458B /* tree_zoom3.png */; };
-		646087A3160D01A700A1458B /* tree_zoom3_highlight.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875B160D01A700A1458B /* tree_zoom3_highlight.png */; };
-		646087A4160D01A700A1458B /* tree_zoom3_plot.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875C160D01A700A1458B /* tree_zoom3_plot.png */; };
-		646087A5160D01A700A1458B /* tree_zoom5.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875D160D01A700A1458B /* tree_zoom5.png */; };
-		646087A6160D01A700A1458B /* tree_zoom5_highlight.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875E160D01A700A1458B /* tree_zoom5_highlight.png */; };
-		646087A7160D01A700A1458B /* tree_zoom5_plot.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460875F160D01A700A1458B /* tree_zoom5_plot.png */; };
-		646087A8160D01A700A1458B /* tree_zoom6.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608760160D01A700A1458B /* tree_zoom6.png */; };
-		646087A9160D01A700A1458B /* tree_zoom6_highlight.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608761160D01A700A1458B /* tree_zoom6_highlight.png */; };
-		646087AA160D01A700A1458B /* tree_zoom6_plot.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608762160D01A700A1458B /* tree_zoom6_plot.png */; };
-		646087AB160D01A700A1458B /* tree_zoom7.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608763160D01A700A1458B /* tree_zoom7.png */; };
-		646087AC160D01A700A1458B /* tree_zoom7_highlight.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608764160D01A700A1458B /* tree_zoom7_highlight.png */; };
-		646087AD160D01A700A1458B /* tree_zoom7_plot.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608765160D01A700A1458B /* tree_zoom7_plot.png */; };
-		646087AE160D01A700A1458B /* marker-selected-sm.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608766160D01A700A1458B /* marker-selected-sm.png */; };
-		646087B1160D01A700A1458B /* pending-approved.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608769160D01A700A1458B /* pending-approved.png */; };
-		646087B2160D01A700A1458B /* pending-approved@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876A160D01A700A1458B /* pending-approved@2x.png */; };
-		646087B3160D01A700A1458B /* pending-unapproved.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876B160D01A700A1458B /* pending-unapproved.png */; };
-		646087B4160D01A700A1458B /* pending-unapproved@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876C160D01A700A1458B /* pending-unapproved@2x.png */; };
-		646087B5160D01A700A1458B /* profile.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876D160D01A700A1458B /* profile.png */; };
-		646087B6160D01A700A1458B /* profile@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876E160D01A700A1458B /* profile@2x.png */; };
-		646087B7160D01A700A1458B /* recent_trees.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460876F160D01A700A1458B /* recent_trees.png */; };
-		646087B8160D01A700A1458B /* recent_trees@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608770160D01A700A1458B /* recent_trees@2x.png */; };
-		646087B9160D01A700A1458B /* selected_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608771160D01A700A1458B /* selected_marker.png */; };
-		646087BA160D01A700A1458B /* selected_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608772160D01A700A1458B /* selected_marker@2x.png */; };
-		646087BB160D01A700A1458B /* selected_marker_small.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608773160D01A700A1458B /* selected_marker_small.png */; };
-		646087BC160D01A700A1458B /* selected_marker_small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608774160D01A700A1458B /* selected_marker_small@2x.png */; };
-		646087BD160D01A700A1458B /* splash_screen.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608775160D01A700A1458B /* splash_screen.png */; };
-		646087BE160D01A700A1458B /* splash_screen@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608776160D01A700A1458B /* splash_screen@2x.png */; };
-		646087BF160D01A700A1458B /* transparent_14.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608777160D01A700A1458B /* transparent_14.png */; };
-		646087C0160D01A700A1458B /* tree_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608778160D01A700A1458B /* tree_icon.png */; };
-		646087C1160D01A700A1458B /* tree_map.png in Resources */ = {isa = PBXBuildFile; fileRef = 64608779160D01A700A1458B /* tree_map.png */; };
-		646087C2160D01A700A1458B /* tree_map@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6460877A160D01A700A1458B /* tree_map@2x.png */; };
 		646087C3160D01A700A1458B /* Implementation.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6460877B160D01A700A1458B /* Implementation.plist */; };
 		646087CC160D01D900A1458B /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C5160D01D900A1458B /* Default.png */; };
 		646087CD160D01D900A1458B /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C6160D01D900A1458B /* Default@2x.png */; };
-		646087CE160D01D900A1458B /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C7160D01D900A1458B /* Icon-72.png */; };
-		646087CF160D01D900A1458B /* Icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C8160D01D900A1458B /* Icon-72@2x.png */; };
-		646087D0160D01D900A1458B /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C9160D01D900A1458B /* Icon.png */; };
-		646087D1160D01D900A1458B /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087CA160D01D900A1458B /* Icon@2x.png */; };
-		647E44531641796B000CF872 /* about_header@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 647E44521641796B000CF872 /* about_header@2x.png */; };
-		647E445516417979000CF872 /* about_footer@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 647E445416417979000CF872 /* about_footer@2x.png */; };
+		6470BEB418DB7FF800C56A8F /* Chevron_left.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9218DB7FF800C56A8F /* Chevron_left.png */; };
+		6470BEB518DB7FF800C56A8F /* Chevron_left@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */; };
+		6470BEB618DB7FF800C56A8F /* Chevron_right.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9418DB7FF800C56A8F /* Chevron_right.png */; };
+		6470BEB718DB7FF800C56A8F /* Chevron_right@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */; };
+		6470BEB818DB7FF800C56A8F /* Default_feature-image.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9618DB7FF800C56A8F /* Default_feature-image.png */; };
+		6470BEB918DB7FF800C56A8F /* Default_feature-image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */; };
+		6470BEBA18DB7FF800C56A8F /* handle_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9818DB7FF800C56A8F /* handle_icon.png */; };
+		6470BEBB18DB7FF800C56A8F /* handle_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */; };
+		6470BEBC18DB7FF800C56A8F /* Profile_favorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */; };
+		6470BEBD18DB7FF800C56A8F /* Profile_favorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */; };
+		6470BEBE18DB7FF800C56A8F /* Profile_unfavorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */; };
+		6470BEBF18DB7FF800C56A8F /* Profile_unfavorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */; };
+		6470BEC018DB7FF800C56A8F /* selected_marker_small.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */; };
+		6470BEC118DB7FF800C56A8F /* selected_marker_small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */; };
+		6470BEC218DB7FF800C56A8F /* selected_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA018DB7FF800C56A8F /* selected_marker.png */; };
+		6470BEC318DB7FF800C56A8F /* selected_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */; };
+		6470BEC418DB7FF800C56A8F /* TabBar_about-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */; };
+		6470BEC518DB7FF800C56A8F /* TabBar_about-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */; };
+		6470BEC618DB7FF800C56A8F /* TabBar_about.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA418DB7FF800C56A8F /* TabBar_about.png */; };
+		6470BEC718DB7FF800C56A8F /* TabBar_about@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */; };
+		6470BEC818DB7FF800C56A8F /* TabBar_details-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */; };
+		6470BEC918DB7FF800C56A8F /* TabBar_details-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */; };
+		6470BECA18DB7FF800C56A8F /* TabBar_details.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA818DB7FF800C56A8F /* TabBar_details.png */; };
+		6470BECB18DB7FF800C56A8F /* TabBar_details@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */; };
+		6470BECC18DB7FF800C56A8F /* TabBar_profile-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */; };
+		6470BECD18DB7FF800C56A8F /* TabBar_profile-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */; };
+		6470BECE18DB7FF800C56A8F /* TabBar_profile.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */; };
+		6470BECF18DB7FF800C56A8F /* TabBar_profile@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */; };
+		6470BED018DB7FF800C56A8F /* TabBar_treemap-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */; };
+		6470BED118DB7FF800C56A8F /* TabBar_treemap-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */; };
+		6470BED218DB7FF800C56A8F /* TabBar_treemap.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */; };
+		6470BED318DB7FF800C56A8F /* TabBar_treemap@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */; };
+		6470BED418DB7FF800C56A8F /* Treemap_Contactbook.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */; };
+		6470BED518DB7FF800C56A8F /* Treemap_Contactbook@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */; };
+		6470BED718DB8A6100C56A8F /* Default-568@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BED618DB8A6100C56A8F /* Default-568@2x.png */; };
+		6470BEE418DB8C0B00C56A8F /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE018DB8C0B00C56A8F /* Icon-72.png */; };
+		6470BEE518DB8C0B00C56A8F /* Icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE118DB8C0B00C56A8F /* Icon-72@2x.png */; };
+		6470BEE618DB8C0B00C56A8F /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE218DB8C0B00C56A8F /* Icon.png */; };
+		6470BEE718DB8C0B00C56A8F /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE318DB8C0B00C56A8F /* Icon@2x.png */; };
 		647E445716417BDF000CF872 /* about.html in Resources */ = {isa = PBXBuildFile; fileRef = 647E445616417BDF000CF872 /* about.html */; };
 		64DDCDB514F51ADF004FA0CF /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64DDCDB414F51ADF004FA0CF /* CoreLocation.framework */; };
 		64DDCDB714F51AF6004FA0CF /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64DDCDB614F51AF6004FA0CF /* MapKit.framework */; };
@@ -183,6 +154,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6452955118D89D3400362A0F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		64582DAC164165C200CF5DB9 /* OTMAboutViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMAboutViewController.h; sourceTree = "<group>"; };
 		64582DAD164165C200CF5DB9 /* OTMAboutViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMAboutViewController.m; sourceTree = "<group>"; };
 		64608647160CFB0A00A1458B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -315,78 +287,48 @@
 		646086E9160CFB6700A1458B /* OTMTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMTableView.m; sourceTree = "<group>"; };
 		646086EA160CFB6700A1458B /* OTMView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMView.h; sourceTree = "<group>"; };
 		646086EB160CFB6700A1458B /* OTMView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMView.m; sourceTree = "<group>"; };
-		64608739160D01A700A1458B /* about.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = about.png; sourceTree = "<group>"; };
-		6460873A160D01A700A1458B /* about@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "about@2x.png"; sourceTree = "<group>"; };
-		6460873B160D01A700A1458B /* about_bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = about_bg.png; sourceTree = "<group>"; };
-		6460873C160D01A700A1458B /* about_bg@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "about_bg@2x.png"; sourceTree = "<group>"; };
-		6460873D160D01A700A1458B /* add_help_bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = add_help_bg.png; sourceTree = "<group>"; };
-		6460873E160D01A700A1458B /* add_help_bg@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "add_help_bg@2x.png"; sourceTree = "<group>"; };
-		6460873F160D01A700A1458B /* add_new.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = add_new.png; sourceTree = "<group>"; };
-		64608740160D01A700A1458B /* add_new@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "add_new@2x.png"; sourceTree = "<group>"; };
-		64608741160D01A700A1458B /* btn_bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = btn_bg.png; sourceTree = "<group>"; };
-		64608742160D01A700A1458B /* btn_bg@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "btn_bg@2x.png"; sourceTree = "<group>"; };
-		64608743160D01A700A1458B /* button_glass_red.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = button_glass_red.png; sourceTree = "<group>"; };
-		64608744160D01A700A1458B /* button_glass_red@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "button_glass_red@2x.png"; sourceTree = "<group>"; };
-		64608745160D01A700A1458B /* detail.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = detail.png; sourceTree = "<group>"; };
-		64608746160D01A700A1458B /* filter_status_bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = filter_status_bg.png; sourceTree = "<group>"; };
-		64608747160D01A700A1458B /* filter_status_bg@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "filter_status_bg@2x.png"; sourceTree = "<group>"; };
-		64608748160D01A700A1458B /* gps_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gps_icon.png; sourceTree = "<group>"; };
-		64608749160D01A700A1458B /* gps_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gps_icon@2x.png"; sourceTree = "<group>"; };
-		6460874A160D01A700A1458B /* gps_icon_14.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gps_icon_14.png; sourceTree = "<group>"; };
-		6460874B160D01A700A1458B /* gps_icon_14@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gps_icon_14@2x.png"; sourceTree = "<group>"; };
-		6460874C160D01A700A1458B /* handle_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = handle_icon.png; sourceTree = "<group>"; };
-		6460874D160D01A700A1458B /* handle_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "handle_icon@2x.png"; sourceTree = "<group>"; };
-		6460874E160D01A700A1458B /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
-		6460874F160D01A700A1458B /* logo@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo@2x.png"; sourceTree = "<group>"; };
-		64608751160D01A700A1458B /* tree_search.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search.png; sourceTree = "<group>"; };
-		64608752160D01A700A1458B /* tree_search_zoom1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search_zoom1.png; sourceTree = "<group>"; };
-		64608753160D01A700A1458B /* tree_search_zoom3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search_zoom3.png; sourceTree = "<group>"; };
-		64608754160D01A700A1458B /* tree_search_zoom5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search_zoom5.png; sourceTree = "<group>"; };
-		64608755160D01A700A1458B /* tree_search_zoom6.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search_zoom6.png; sourceTree = "<group>"; };
-		64608756160D01A700A1458B /* tree_search_zoom7.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_search_zoom7.png; sourceTree = "<group>"; };
-		64608757160D01A700A1458B /* tree_zoom1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom1.png; sourceTree = "<group>"; };
-		64608758160D01A700A1458B /* tree_zoom1_highlight.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom1_highlight.png; sourceTree = "<group>"; };
-		64608759160D01A700A1458B /* tree_zoom1_plot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom1_plot.png; sourceTree = "<group>"; };
-		6460875A160D01A700A1458B /* tree_zoom3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom3.png; sourceTree = "<group>"; };
-		6460875B160D01A700A1458B /* tree_zoom3_highlight.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom3_highlight.png; sourceTree = "<group>"; };
-		6460875C160D01A700A1458B /* tree_zoom3_plot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom3_plot.png; sourceTree = "<group>"; };
-		6460875D160D01A700A1458B /* tree_zoom5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom5.png; sourceTree = "<group>"; };
-		6460875E160D01A700A1458B /* tree_zoom5_highlight.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom5_highlight.png; sourceTree = "<group>"; };
-		6460875F160D01A700A1458B /* tree_zoom5_plot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom5_plot.png; sourceTree = "<group>"; };
-		64608760160D01A700A1458B /* tree_zoom6.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom6.png; sourceTree = "<group>"; };
-		64608761160D01A700A1458B /* tree_zoom6_highlight.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom6_highlight.png; sourceTree = "<group>"; };
-		64608762160D01A700A1458B /* tree_zoom6_plot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom6_plot.png; sourceTree = "<group>"; };
-		64608763160D01A700A1458B /* tree_zoom7.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom7.png; sourceTree = "<group>"; };
-		64608764160D01A700A1458B /* tree_zoom7_highlight.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom7_highlight.png; sourceTree = "<group>"; };
-		64608765160D01A700A1458B /* tree_zoom7_plot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_zoom7_plot.png; sourceTree = "<group>"; };
-		64608766160D01A700A1458B /* marker-selected-sm.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "marker-selected-sm.png"; sourceTree = "<group>"; };
-		64608769160D01A700A1458B /* pending-approved.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pending-approved.png"; sourceTree = "<group>"; };
-		6460876A160D01A700A1458B /* pending-approved@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pending-approved@2x.png"; sourceTree = "<group>"; };
-		6460876B160D01A700A1458B /* pending-unapproved.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pending-unapproved.png"; sourceTree = "<group>"; };
-		6460876C160D01A700A1458B /* pending-unapproved@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pending-unapproved@2x.png"; sourceTree = "<group>"; };
-		6460876D160D01A700A1458B /* profile.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = profile.png; sourceTree = "<group>"; };
-		6460876E160D01A700A1458B /* profile@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "profile@2x.png"; sourceTree = "<group>"; };
-		6460876F160D01A700A1458B /* recent_trees.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = recent_trees.png; sourceTree = "<group>"; };
-		64608770160D01A700A1458B /* recent_trees@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "recent_trees@2x.png"; sourceTree = "<group>"; };
-		64608771160D01A700A1458B /* selected_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = selected_marker.png; sourceTree = "<group>"; };
-		64608772160D01A700A1458B /* selected_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "selected_marker@2x.png"; sourceTree = "<group>"; };
-		64608773160D01A700A1458B /* selected_marker_small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = selected_marker_small.png; sourceTree = "<group>"; };
-		64608774160D01A700A1458B /* selected_marker_small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "selected_marker_small@2x.png"; sourceTree = "<group>"; };
-		64608775160D01A700A1458B /* splash_screen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = splash_screen.png; sourceTree = "<group>"; };
-		64608776160D01A700A1458B /* splash_screen@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "splash_screen@2x.png"; sourceTree = "<group>"; };
-		64608777160D01A700A1458B /* transparent_14.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = transparent_14.png; sourceTree = "<group>"; };
-		64608778160D01A700A1458B /* tree_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_icon.png; sourceTree = "<group>"; };
-		64608779160D01A700A1458B /* tree_map.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tree_map.png; sourceTree = "<group>"; };
-		6460877A160D01A700A1458B /* tree_map@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "tree_map@2x.png"; sourceTree = "<group>"; };
 		6460877B160D01A700A1458B /* Implementation.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Implementation.plist; sourceTree = "<group>"; };
 		646087C5160D01D900A1458B /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		646087C6160D01D900A1458B /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
-		646087C7160D01D900A1458B /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72.png"; sourceTree = "<group>"; };
-		646087C8160D01D900A1458B /* Icon-72@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72@2x.png"; sourceTree = "<group>"; };
-		646087C9160D01D900A1458B /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
-		646087CA160D01D900A1458B /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon@2x.png"; sourceTree = "<group>"; };
-		647E44521641796B000CF872 /* about_header@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "about_header@2x.png"; sourceTree = "<group>"; };
-		647E445416417979000CF872 /* about_footer@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "about_footer@2x.png"; sourceTree = "<group>"; };
+		6470BE9218DB7FF800C56A8F /* Chevron_left.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Chevron_left.png; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_left.png"; sourceTree = "<group>"; };
+		6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Chevron_left@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_left@2x.png"; sourceTree = "<group>"; };
+		6470BE9418DB7FF800C56A8F /* Chevron_right.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Chevron_right.png; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_right.png"; sourceTree = "<group>"; };
+		6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Chevron_right@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_right@2x.png"; sourceTree = "<group>"; };
+		6470BE9618DB7FF800C56A8F /* Default_feature-image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default_feature-image.png"; path = "../../../../otm-mobile-skins/la/ios/images/Default_feature-image.png"; sourceTree = "<group>"; };
+		6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default_feature-image@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Default_feature-image@2x.png"; sourceTree = "<group>"; };
+		6470BE9818DB7FF800C56A8F /* handle_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = handle_icon.png; path = "../../../../otm-mobile-skins/la/ios/images/handle_icon.png"; sourceTree = "<group>"; };
+		6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "handle_icon@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/handle_icon@2x.png"; sourceTree = "<group>"; };
+		6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Profile_favorited.png; path = "../../../../otm-mobile-skins/la/ios/images/Profile_favorited.png"; sourceTree = "<group>"; };
+		6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Profile_favorited@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Profile_favorited@2x.png"; sourceTree = "<group>"; };
+		6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Profile_unfavorited.png; path = "../../../../otm-mobile-skins/la/ios/images/Profile_unfavorited.png"; sourceTree = "<group>"; };
+		6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Profile_unfavorited@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Profile_unfavorited@2x.png"; sourceTree = "<group>"; };
+		6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = selected_marker_small.png; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker_small.png"; sourceTree = "<group>"; };
+		6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "selected_marker_small@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker_small@2x.png"; sourceTree = "<group>"; };
+		6470BEA018DB7FF800C56A8F /* selected_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = selected_marker.png; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker.png"; sourceTree = "<group>"; };
+		6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "selected_marker@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker@2x.png"; sourceTree = "<group>"; };
+		6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about-active.png"; sourceTree = "<group>"; };
+		6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about-active@2x.png"; sourceTree = "<group>"; };
+		6470BEA418DB7FF800C56A8F /* TabBar_about.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_about.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about.png"; sourceTree = "<group>"; };
+		6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about@2x.png"; sourceTree = "<group>"; };
+		6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details-active.png"; sourceTree = "<group>"; };
+		6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details-active@2x.png"; sourceTree = "<group>"; };
+		6470BEA818DB7FF800C56A8F /* TabBar_details.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_details.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details.png"; sourceTree = "<group>"; };
+		6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details@2x.png"; sourceTree = "<group>"; };
+		6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile-active.png"; sourceTree = "<group>"; };
+		6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile-active@2x.png"; sourceTree = "<group>"; };
+		6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_profile.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile.png"; sourceTree = "<group>"; };
+		6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile@2x.png"; sourceTree = "<group>"; };
+		6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap-active.png"; sourceTree = "<group>"; };
+		6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap-active@2x.png"; sourceTree = "<group>"; };
+		6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_treemap.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap.png"; sourceTree = "<group>"; };
+		6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap@2x.png"; sourceTree = "<group>"; };
+		6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Treemap_Contactbook.png; path = "../../../../otm-mobile-skins/la/ios/images/Treemap_Contactbook.png"; sourceTree = "<group>"; };
+		6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Treemap_Contactbook@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Treemap_Contactbook@2x.png"; sourceTree = "<group>"; };
+		6470BED618DB8A6100C56A8F /* Default-568@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568@2x.png"; sourceTree = "<group>"; };
+		6470BEE018DB8C0B00C56A8F /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72.png"; sourceTree = "<group>"; };
+		6470BEE118DB8C0B00C56A8F /* Icon-72@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72@2x.png"; sourceTree = "<group>"; };
+		6470BEE218DB8C0B00C56A8F /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
+		6470BEE318DB8C0B00C56A8F /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon@2x.png"; sourceTree = "<group>"; };
 		647E445616417BDF000CF872 /* about.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = about.html; sourceTree = "<group>"; };
 		64DDCDB414F51ADF004FA0CF /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		64DDCDB614F51AF6004FA0CF /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
@@ -415,6 +357,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6452955218D89D3400362A0F /* QuartzCore.framework in Frameworks */,
 				D7C990291518C89F0094770C /* libz.dylib in Frameworks */,
 				E943971B14F447EB007CD0D1 /* CoreGraphics.framework in Frameworks */,
 				D7C990271518C88F0094770C /* MobileCoreServices.framework in Frameworks */,
@@ -690,92 +633,54 @@
 		64608738160D01A700A1458B /* images */ = {
 			isa = PBXGroup;
 			children = (
-				64608739160D01A700A1458B /* about.png */,
-				6460873A160D01A700A1458B /* about@2x.png */,
-				6460873B160D01A700A1458B /* about_bg.png */,
-				6460873C160D01A700A1458B /* about_bg@2x.png */,
-				647E44521641796B000CF872 /* about_header@2x.png */,
-				647E445416417979000CF872 /* about_footer@2x.png */,
-				6460873D160D01A700A1458B /* add_help_bg.png */,
-				6460873E160D01A700A1458B /* add_help_bg@2x.png */,
-				6460873F160D01A700A1458B /* add_new.png */,
-				64608740160D01A700A1458B /* add_new@2x.png */,
-				64608741160D01A700A1458B /* btn_bg.png */,
-				64608742160D01A700A1458B /* btn_bg@2x.png */,
-				64608743160D01A700A1458B /* button_glass_red.png */,
-				64608744160D01A700A1458B /* button_glass_red@2x.png */,
-				64608745160D01A700A1458B /* detail.png */,
-				64608746160D01A700A1458B /* filter_status_bg.png */,
-				64608747160D01A700A1458B /* filter_status_bg@2x.png */,
-				64608748160D01A700A1458B /* gps_icon.png */,
-				64608749160D01A700A1458B /* gps_icon@2x.png */,
-				6460874A160D01A700A1458B /* gps_icon_14.png */,
-				6460874B160D01A700A1458B /* gps_icon_14@2x.png */,
-				6460874C160D01A700A1458B /* handle_icon.png */,
-				6460874D160D01A700A1458B /* handle_icon@2x.png */,
-				6460874E160D01A700A1458B /* logo.png */,
-				6460874F160D01A700A1458B /* logo@2x.png */,
-				64608750160D01A700A1458B /* map_icons */,
-				64608766160D01A700A1458B /* marker-selected-sm.png */,
-				64608769160D01A700A1458B /* pending-approved.png */,
-				6460876A160D01A700A1458B /* pending-approved@2x.png */,
-				6460876B160D01A700A1458B /* pending-unapproved.png */,
-				6460876C160D01A700A1458B /* pending-unapproved@2x.png */,
-				6460876D160D01A700A1458B /* profile.png */,
-				6460876E160D01A700A1458B /* profile@2x.png */,
-				6460876F160D01A700A1458B /* recent_trees.png */,
-				64608770160D01A700A1458B /* recent_trees@2x.png */,
-				64608771160D01A700A1458B /* selected_marker.png */,
-				64608772160D01A700A1458B /* selected_marker@2x.png */,
-				64608773160D01A700A1458B /* selected_marker_small.png */,
-				64608774160D01A700A1458B /* selected_marker_small@2x.png */,
-				64608775160D01A700A1458B /* splash_screen.png */,
-				64608776160D01A700A1458B /* splash_screen@2x.png */,
-				64608777160D01A700A1458B /* transparent_14.png */,
-				64608778160D01A700A1458B /* tree_icon.png */,
-				64608779160D01A700A1458B /* tree_map.png */,
-				6460877A160D01A700A1458B /* tree_map@2x.png */,
+				6470BE9218DB7FF800C56A8F /* Chevron_left.png */,
+				6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */,
+				6470BE9418DB7FF800C56A8F /* Chevron_right.png */,
+				6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */,
+				6470BE9618DB7FF800C56A8F /* Default_feature-image.png */,
+				6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */,
+				6470BE9818DB7FF800C56A8F /* handle_icon.png */,
+				6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */,
+				6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */,
+				6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */,
+				6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */,
+				6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */,
+				6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */,
+				6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */,
+				6470BEA018DB7FF800C56A8F /* selected_marker.png */,
+				6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */,
+				6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */,
+				6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */,
+				6470BEA418DB7FF800C56A8F /* TabBar_about.png */,
+				6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */,
+				6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */,
+				6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */,
+				6470BEA818DB7FF800C56A8F /* TabBar_details.png */,
+				6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */,
+				6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */,
+				6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */,
+				6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */,
+				6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */,
+				6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */,
+				6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */,
+				6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */,
+				6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */,
+				6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */,
+				6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */,
 			);
 			path = images;
-			sourceTree = "<group>";
-		};
-		64608750160D01A700A1458B /* map_icons */ = {
-			isa = PBXGroup;
-			children = (
-				64608751160D01A700A1458B /* tree_search.png */,
-				64608752160D01A700A1458B /* tree_search_zoom1.png */,
-				64608753160D01A700A1458B /* tree_search_zoom3.png */,
-				64608754160D01A700A1458B /* tree_search_zoom5.png */,
-				64608755160D01A700A1458B /* tree_search_zoom6.png */,
-				64608756160D01A700A1458B /* tree_search_zoom7.png */,
-				64608757160D01A700A1458B /* tree_zoom1.png */,
-				64608758160D01A700A1458B /* tree_zoom1_highlight.png */,
-				64608759160D01A700A1458B /* tree_zoom1_plot.png */,
-				6460875A160D01A700A1458B /* tree_zoom3.png */,
-				6460875B160D01A700A1458B /* tree_zoom3_highlight.png */,
-				6460875C160D01A700A1458B /* tree_zoom3_plot.png */,
-				6460875D160D01A700A1458B /* tree_zoom5.png */,
-				6460875E160D01A700A1458B /* tree_zoom5_highlight.png */,
-				6460875F160D01A700A1458B /* tree_zoom5_plot.png */,
-				64608760160D01A700A1458B /* tree_zoom6.png */,
-				64608761160D01A700A1458B /* tree_zoom6_highlight.png */,
-				64608762160D01A700A1458B /* tree_zoom6_plot.png */,
-				64608763160D01A700A1458B /* tree_zoom7.png */,
-				64608764160D01A700A1458B /* tree_zoom7_highlight.png */,
-				64608765160D01A700A1458B /* tree_zoom7_plot.png */,
-			);
-			path = map_icons;
 			sourceTree = "<group>";
 		};
 		E943970714F447EB007CD0D1 = {
 			isa = PBXGroup;
 			children = (
+				6470BED618DB8A6100C56A8F /* Default-568@2x.png */,
 				646087C5160D01D900A1458B /* Default.png */,
 				646087C6160D01D900A1458B /* Default@2x.png */,
-				646087C9160D01D900A1458B /* Icon.png */,
-				646087CA160D01D900A1458B /* Icon@2x.png */,
-				646087C7160D01D900A1458B /* Icon-72.png */,
-				646087C8160D01D900A1458B /* Icon-72@2x.png */,
+				6470BEE018DB8C0B00C56A8F /* Icon-72.png */,
+				6470BEE118DB8C0B00C56A8F /* Icon-72@2x.png */,
+				6470BEE218DB8C0B00C56A8F /* Icon.png */,
+				6470BEE318DB8C0B00C56A8F /* Icon@2x.png */,
 				64608646160CFB0A00A1458B /* InfoPlist.strings */,
 				64608649160CFB2800A1458B /* OpenTreeMap-Info.plist */,
 				6460864A160CFB2800A1458B /* OpenTreeMap.entitlements */,
@@ -799,6 +704,7 @@
 		E943971514F447EB007CD0D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6452955118D89D3400362A0F /* QuartzCore.framework */,
 				D7C990281518C89F0094770C /* libz.dylib */,
 				D7C990261518C88F0094770C /* MobileCoreServices.framework */,
 				D7C990241518C8890094770C /* SystemConfiguration.framework */,
@@ -886,6 +792,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6470BEE618DB8C0B00C56A8F /* Icon.png in Resources */,
 				64608648160CFB0A00A1458B /* InfoPlist.strings in Resources */,
 				6460864B160CFB2800A1458B /* OpenTreeMap-Info.plist in Resources */,
 				6460864C160CFB2800A1458B /* OpenTreeMap.entitlements in Resources */,
@@ -894,79 +801,48 @@
 				64608655160CFB4600A1458B /* MainStoryboard_iPhone.storyboard in Resources */,
 				64608656160CFB4600A1458B /* OTMBenefitsTableViewCell.xib in Resources */,
 				64608657160CFB4600A1458B /* OTMDBHTableViewCell.xib in Resources */,
-				64608782160D01A700A1458B /* about.png in Resources */,
-				64608783160D01A700A1458B /* about@2x.png in Resources */,
-				64608784160D01A700A1458B /* about_bg.png in Resources */,
-				64608785160D01A700A1458B /* about_bg@2x.png in Resources */,
-				64608786160D01A700A1458B /* add_help_bg.png in Resources */,
-				64608787160D01A700A1458B /* add_help_bg@2x.png in Resources */,
-				64608788160D01A700A1458B /* add_new.png in Resources */,
-				64608789160D01A700A1458B /* add_new@2x.png in Resources */,
-				6460878A160D01A700A1458B /* btn_bg.png in Resources */,
-				6460878B160D01A700A1458B /* btn_bg@2x.png in Resources */,
-				6460878C160D01A700A1458B /* button_glass_red.png in Resources */,
-				6460878D160D01A700A1458B /* button_glass_red@2x.png in Resources */,
-				6460878E160D01A700A1458B /* detail.png in Resources */,
-				6460878F160D01A700A1458B /* filter_status_bg.png in Resources */,
-				64608790160D01A700A1458B /* filter_status_bg@2x.png in Resources */,
-				64608791160D01A700A1458B /* gps_icon.png in Resources */,
-				64608792160D01A700A1458B /* gps_icon@2x.png in Resources */,
-				64608793160D01A700A1458B /* gps_icon_14.png in Resources */,
-				64608794160D01A700A1458B /* gps_icon_14@2x.png in Resources */,
-				64608795160D01A700A1458B /* handle_icon.png in Resources */,
-				64608796160D01A700A1458B /* handle_icon@2x.png in Resources */,
-				64608797160D01A700A1458B /* logo.png in Resources */,
-				64608798160D01A700A1458B /* logo@2x.png in Resources */,
-				64608799160D01A700A1458B /* tree_search.png in Resources */,
-				6460879A160D01A700A1458B /* tree_search_zoom1.png in Resources */,
-				6460879B160D01A700A1458B /* tree_search_zoom3.png in Resources */,
-				6460879C160D01A700A1458B /* tree_search_zoom5.png in Resources */,
-				6460879D160D01A700A1458B /* tree_search_zoom6.png in Resources */,
-				6460879E160D01A700A1458B /* tree_search_zoom7.png in Resources */,
-				6460879F160D01A700A1458B /* tree_zoom1.png in Resources */,
-				646087A0160D01A700A1458B /* tree_zoom1_highlight.png in Resources */,
-				646087A1160D01A700A1458B /* tree_zoom1_plot.png in Resources */,
-				646087A2160D01A700A1458B /* tree_zoom3.png in Resources */,
-				646087A3160D01A700A1458B /* tree_zoom3_highlight.png in Resources */,
-				646087A4160D01A700A1458B /* tree_zoom3_plot.png in Resources */,
-				646087A5160D01A700A1458B /* tree_zoom5.png in Resources */,
-				646087A6160D01A700A1458B /* tree_zoom5_highlight.png in Resources */,
-				646087A7160D01A700A1458B /* tree_zoom5_plot.png in Resources */,
-				646087A8160D01A700A1458B /* tree_zoom6.png in Resources */,
-				646087A9160D01A700A1458B /* tree_zoom6_highlight.png in Resources */,
-				646087AA160D01A700A1458B /* tree_zoom6_plot.png in Resources */,
-				646087AB160D01A700A1458B /* tree_zoom7.png in Resources */,
-				646087AC160D01A700A1458B /* tree_zoom7_highlight.png in Resources */,
-				646087AD160D01A700A1458B /* tree_zoom7_plot.png in Resources */,
-				646087AE160D01A700A1458B /* marker-selected-sm.png in Resources */,
-				646087B1160D01A700A1458B /* pending-approved.png in Resources */,
-				646087B2160D01A700A1458B /* pending-approved@2x.png in Resources */,
-				646087B3160D01A700A1458B /* pending-unapproved.png in Resources */,
-				646087B4160D01A700A1458B /* pending-unapproved@2x.png in Resources */,
-				646087B5160D01A700A1458B /* profile.png in Resources */,
-				646087B6160D01A700A1458B /* profile@2x.png in Resources */,
-				646087B7160D01A700A1458B /* recent_trees.png in Resources */,
-				646087B8160D01A700A1458B /* recent_trees@2x.png in Resources */,
-				646087B9160D01A700A1458B /* selected_marker.png in Resources */,
-				646087BA160D01A700A1458B /* selected_marker@2x.png in Resources */,
-				646087BB160D01A700A1458B /* selected_marker_small.png in Resources */,
-				646087BC160D01A700A1458B /* selected_marker_small@2x.png in Resources */,
-				646087BD160D01A700A1458B /* splash_screen.png in Resources */,
-				646087BE160D01A700A1458B /* splash_screen@2x.png in Resources */,
-				646087BF160D01A700A1458B /* transparent_14.png in Resources */,
-				646087C0160D01A700A1458B /* tree_icon.png in Resources */,
-				646087C1160D01A700A1458B /* tree_map.png in Resources */,
-				646087C2160D01A700A1458B /* tree_map@2x.png in Resources */,
+				6470BEE418DB8C0B00C56A8F /* Icon-72.png in Resources */,
+				6470BECA18DB7FF800C56A8F /* TabBar_details.png in Resources */,
+				6470BED318DB7FF800C56A8F /* TabBar_treemap@2x.png in Resources */,
+				6470BED018DB7FF800C56A8F /* TabBar_treemap-active.png in Resources */,
+				6470BEC418DB7FF800C56A8F /* TabBar_about-active.png in Resources */,
+				6470BECC18DB7FF800C56A8F /* TabBar_profile-active.png in Resources */,
+				6470BEB518DB7FF800C56A8F /* Chevron_left@2x.png in Resources */,
+				6470BEBA18DB7FF800C56A8F /* handle_icon.png in Resources */,
+				6470BEC918DB7FF800C56A8F /* TabBar_details-active@2x.png in Resources */,
+				6470BEC318DB7FF800C56A8F /* selected_marker@2x.png in Resources */,
+				6470BEC618DB7FF800C56A8F /* TabBar_about.png in Resources */,
+				6470BEBD18DB7FF800C56A8F /* Profile_favorited@2x.png in Resources */,
+				6470BEB418DB7FF800C56A8F /* Chevron_left.png in Resources */,
+				6470BEB918DB7FF800C56A8F /* Default_feature-image@2x.png in Resources */,
+				6470BEC018DB7FF800C56A8F /* selected_marker_small.png in Resources */,
+				6470BED518DB7FF800C56A8F /* Treemap_Contactbook@2x.png in Resources */,
+				6470BEBB18DB7FF800C56A8F /* handle_icon@2x.png in Resources */,
+				6470BED118DB7FF800C56A8F /* TabBar_treemap-active@2x.png in Resources */,
+				6470BEBC18DB7FF800C56A8F /* Profile_favorited.png in Resources */,
+				6470BEC518DB7FF800C56A8F /* TabBar_about-active@2x.png in Resources */,
+				6470BED418DB7FF800C56A8F /* Treemap_Contactbook.png in Resources */,
+				6470BEC118DB7FF800C56A8F /* selected_marker_small@2x.png in Resources */,
+				6470BECF18DB7FF800C56A8F /* TabBar_profile@2x.png in Resources */,
+				6470BEB818DB7FF800C56A8F /* Default_feature-image.png in Resources */,
+				6470BEBF18DB7FF800C56A8F /* Profile_unfavorited@2x.png in Resources */,
+				6470BEB618DB7FF800C56A8F /* Chevron_right.png in Resources */,
+				6470BECD18DB7FF800C56A8F /* TabBar_profile-active@2x.png in Resources */,
+				6470BECE18DB7FF800C56A8F /* TabBar_profile.png in Resources */,
+				6470BEC218DB7FF800C56A8F /* selected_marker.png in Resources */,
+				6470BECB18DB7FF800C56A8F /* TabBar_details@2x.png in Resources */,
+				6470BEC818DB7FF800C56A8F /* TabBar_details-active.png in Resources */,
 				646087C3160D01A700A1458B /* Implementation.plist in Resources */,
 				646087CC160D01D900A1458B /* Default.png in Resources */,
 				646087CD160D01D900A1458B /* Default@2x.png in Resources */,
-				646087CE160D01D900A1458B /* Icon-72.png in Resources */,
-				646087CF160D01D900A1458B /* Icon-72@2x.png in Resources */,
-				646087D0160D01D900A1458B /* Icon.png in Resources */,
-				646087D1160D01D900A1458B /* Icon@2x.png in Resources */,
-				647E44531641796B000CF872 /* about_header@2x.png in Resources */,
-				647E445516417979000CF872 /* about_footer@2x.png in Resources */,
 				647E445716417BDF000CF872 /* about.html in Resources */,
+				6470BEB718DB7FF800C56A8F /* Chevron_right@2x.png in Resources */,
+				6470BEE718DB8C0B00C56A8F /* Icon@2x.png in Resources */,
+				6470BEE518DB8C0B00C56A8F /* Icon-72@2x.png in Resources */,
+				6470BED718DB8A6100C56A8F /* Default-568@2x.png in Resources */,
+				6470BEC718DB7FF800C56A8F /* TabBar_about@2x.png in Resources */,
+				6470BED218DB7FF800C56A8F /* TabBar_treemap.png in Resources */,
+				6470BEBE18DB7FF800C56A8F /* Profile_unfavorited.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenTreeMap/resources/LoginRequiredView.xib
+++ b/OpenTreeMap/resources/LoginRequiredView.xib
@@ -1,313 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1296</int>
-		<string key="IBDocument.SystemVersion">11E53</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
-		<string key="IBDocument.AppKitVersion">1138.47</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1181</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBUIButton</string>
-			<string>IBUIImageView</string>
-			<string>IBUIView</string>
-			<string>IBUILabel</string>
-			<string>IBProxyObject</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUIImageView" id="210177560">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{20, 7}, {280, 108}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="752103644"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<int key="IBUIContentMode">1</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<object class="NSCustomResource" key="IBUIImage">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">logo.png</string>
-						</object>
-					</object>
-					<object class="IBUILabel" id="752103644">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 132}, {280, 50}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="553157242"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">You have to login or register to see the profiles page</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MCAwIDAAA</bytes>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<float key="IBUIMinimumFontSize">10</float>
-						<int key="IBUINumberOfLines">2</int>
-						<int key="IBUITextAlignment">1</int>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">1</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUIButton" id="280389775">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 215}, {280, 37}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Login</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor" id="919020629">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<reference key="IBUINormalTitleColor" ref="919020629"/>
-						<object class="NSColor" key="IBUINormalTitleShadowColor" id="1055903168">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="NSCustomResource" key="IBUINormalBackgroundImage">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">ptm_btn_bg.png</string>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="1034108071">
-							<int key="type">2</int>
-							<int key="size">2</int>
-						</object>
-						<object class="NSFont" key="IBUIFont" id="863152009">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">18</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUIButton" id="553157242">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 208}, {280, 51}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="280389775"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Login or Register</string>
-						<reference key="IBUIHighlightedTitleColor" ref="919020629"/>
-						<reference key="IBUINormalTitleColor" ref="919020629"/>
-						<reference key="IBUINormalTitleShadowColor" ref="1055903168"/>
-						<object class="NSCustomResource" key="IBUINormalBackgroundImage">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">btn_bg.png</string>
-						</object>
-						<reference key="IBUIFontDescription" ref="1034108071"/>
-						<reference key="IBUIFont" ref="863152009"/>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 64}, {320, 367}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="210177560"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">2</int>
-					<bytes key="NSRGB">MC45MTM3MjU1NTQ5IDAuOTY0NzA1OTQ0MSAwLjk2MDc4NDM3NTcAA</bytes>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUISimulatedNavigationBarMetrics" key="IBUISimulatedTopBarMetrics">
-					<bool key="IBUIPrompted">NO</bool>
-				</object>
-				<object class="IBUISimulatedTabBarMetrics" key="IBUISimulatedBottomBarMetrics"/>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">pwReqView</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">7</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">doLogin:</string>
-						<reference key="source" ref="553157242"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">8</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="210177560"/>
-							<reference ref="752103644"/>
-							<reference ref="280389775"/>
-							<reference ref="553157242"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">3</int>
-						<reference key="object" ref="210177560"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="752103644"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="280389775"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="553157242"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">OTMProfileViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.CustomClassName">OTMView</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="3.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<real value="0.0" key="5.IBUIButtonInspectorSelectedStateConfigurationMetadataKey"/>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<real value="0.0" key="6.IBUIButtonInspectorSelectedStateConfigurationMetadataKey"/>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">8</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">OTMProfileViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="loadingView">UIView</string>
-						<string key="pwReqView">UIView</string>
-						<string key="tableView">UITableView</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="loadingView">
-							<string key="name">loadingView</string>
-							<string key="candidateClassName">UIView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="pwReqView">
-							<string key="name">pwReqView</string>
-							<string key="candidateClassName">UIView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tableView">
-							<string key="name">tableView</string>
-							<string key="candidateClassName">UITableView</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/OTMProfileViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">OTMView</string>
-					<string key="superclassName">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/OTMView.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1296" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="btn_bg.png">{3, 35}</string>
-			<string key="logo.png">{300, 170}</string>
-			<string key="ptm_btn_bg.png">{3, 35}</string>
-		</dictionary>
-		<string key="IBCocoaTouchPluginVersion">1181</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1280" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OTMProfileViewController">
+            <connections>
+                <outlet property="pwReqView" destination="1" id="7"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1" customClass="OTMView">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="You must log in or register to see your profile" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="10" id="4">
+                    <rect key="frame" x="20" y="132" width="280" height="50"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="6">
+                    <rect key="frame" x="20" y="190" width="280" height="51"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                    <state key="normal" title="Login or Register">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="doLogin:" destination="-1" eventType="touchUpInside" id="8"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="0.96862745100000003" green="0.96862745100000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+        </view>
+    </objects>
+</document>

--- a/OpenTreeMap/resources/LoginStoryboard.storyboard
+++ b/OpenTreeMap/resources/LoginStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="yby-6X-duV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="yby-6X-duV">
     <dependencies>
         <deployment defaultVersion="1280" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
@@ -53,10 +53,7 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="cqW-QL-Yv8" customClass="OTMButton">
                                         <rect key="frame" x="20" y="206" width="280" height="37"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="Login">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
+                                        <state key="normal" title="Login"/>
                                         <connections>
                                             <action selector="attemptLogin:" destination="EnD-Jy-kmP" eventType="touchUpInside" id="n5P-tb-JLK"/>
                                         </connections>
@@ -64,10 +61,7 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="NMm-8N-6Ik" customClass="OTMButton">
                                         <rect key="frame" x="20" y="251" width="280" height="37"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="Forgot Password?">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
+                                        <state key="normal" title="Forgot Password?"/>
                                         <connections>
                                             <segue destination="H9t-wG-bYo" kind="push" id="X2r-h1-V2e"/>
                                         </connections>
@@ -80,22 +74,15 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="H9A-Nd-VAQ" customClass="OTMButton">
                                         <rect key="frame" x="20" y="305" width="280" height="37"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="Register">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
+                                        <state key="normal" title="Register"/>
                                         <connections>
                                             <segue destination="EHZ-o9-hUZ" kind="push" id="w30-MA-MRK"/>
                                         </connections>
                                     </button>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" image="logo.png" id="zdp-Bv-4Jj">
-                                        <rect key="frame" x="20" y="7" width="280" height="108"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    </imageView>
                                 </subviews>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.96862745100000003" green="0.96862745100000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                     <navigationItem key="navigationItem" title="Login" id="AbS-sY-mI2">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="Rbc-pD-x0L">
@@ -150,7 +137,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1201" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="email address" minimumFontSize="17" id="Leg-k9-GO8">
-                                        <rect key="frame" x="20" y="114" width="280" height="31"/>
+                                        <rect key="frame" x="24" y="14" width="280" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
@@ -159,7 +146,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1202" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password" minimumFontSize="17" id="EPK-95-w9t">
-                                        <rect key="frame" x="20" y="150" width="280" height="31"/>
+                                        <rect key="frame" x="24" y="50" width="280" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
@@ -168,7 +155,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1204" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="username" minimumFontSize="17" id="83T-RB-vAP">
-                                        <rect key="frame" x="20" y="221" width="280" height="31"/>
+                                        <rect key="frame" x="24" y="121" width="280" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -177,7 +164,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1203" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="verify password" minimumFontSize="17" id="e39-YE-7jE">
-                                        <rect key="frame" x="20" y="185" width="280" height="31"/>
+                                        <rect key="frame" x="24" y="85" width="280" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
@@ -186,7 +173,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1205" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="first name" minimumFontSize="17" id="bzJ-Z2-gKc">
-                                        <rect key="frame" x="20" y="257" width="134" height="31"/>
+                                        <rect key="frame" x="24" y="157" width="134" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -195,7 +182,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" tag="1206" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="last name" minimumFontSize="17" id="CbR-tg-8o1">
-                                        <rect key="frame" x="166" y="257" width="134" height="31"/>
+                                        <rect key="frame" x="170" y="157" width="134" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -204,10 +191,9 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="fxs-wP-v2T" customClass="OTMButton">
-                                        <rect key="frame" x="87" y="335" width="213" height="66"/>
+                                        <rect key="frame" x="87" y="238" width="213" height="66"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Add Profile Picture">
-                                            <color key="titleColor" red="1" green="0.98690542999999997" blue="0.94762171989999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
                                         <connections>
@@ -215,18 +201,13 @@
                                         </connections>
                                     </button>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" id="9xO-3l-kZO">
-                                        <rect key="frame" x="12" y="335" width="67" height="69"/>
+                                        <rect key="frame" x="24" y="235" width="67" height="69"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="1" green="0.90907542610000003" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                    </imageView>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" image="logo.png" id="6b2-Zt-3vn">
-                                        <rect key="frame" x="20" y="7" width="280" height="108"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </imageView>
                                 </subviews>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="0.98690542999999997" blue="0.94762171989999999" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                     <navigationItem key="navigationItem" title="Create Profile" id="6Uz-Gy-6Uu">
                         <barButtonItem key="rightBarButtonItem" systemItem="done" id="Fma-Oh-J3E">
@@ -270,18 +251,13 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="MTs-kv-CnC" customClass="OTMButton">
                                 <rect key="frame" x="20" y="170" width="280" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Reset Password">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                <state key="normal" title="Send Password Reset Email">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
                                     <action selector="resetPassword:" destination="H9t-wG-bYo" eventType="touchUpInside" id="TdF-je-qb7"/>
                                 </connections>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" image="logo.png" id="U4r-UV-K7e">
-                                <rect key="frame" x="14" y="7" width="280" height="108"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.98690542999999997" blue="0.94762171989999999" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
@@ -297,9 +273,6 @@
             <point key="canvasLocation" x="788" y="-245"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="logo.png" width="300" height="170"/>
-    </resources>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>

--- a/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
+++ b/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="7zY-vH-TMB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="7zY-vH-TMB">
     <dependencies>
         <deployment defaultVersion="1280" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller - Tree Map-->
         <scene sceneID="q3d-8f-SBs">
             <objects>
                 <navigationController definesPresentationContext="YES" id="IOc-fB-8NC" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Tree Map" image="tree_map.png" id="Wk0-IF-fcm"/>
+                    <tabBarItem key="tabBarItem" title="Tree Map" image="TabBar_treemap.png" id="Wk0-IF-fcm"/>
                     <navigationBar key="navigationBar" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="rge-YT-ir8" customClass="OTMNavigationBar">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -32,7 +32,18 @@
                             <view contentMode="scaleToFill" id="HdG-pl-Slh" customClass="MKMapView">
                                 <rect key="frame" x="0.0" y="44" width="320" height="436"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <subviews>
+                                    <searchBar opaque="NO" contentMode="redraw" text="" placeholder="Search Address or Location" translucent="NO" id="tpv-GO-iyB" customClass="OTMSearchBar">
+                                        <rect key="frame" x="0.0" y="85" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="barTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no"/>
+                                        <connections>
+                                            <outlet property="delegate" destination="2" id="NLN-kZ-OGe"/>
+                                        </connections>
+                                    </searchBar>
+                                </subviews>
                             </view>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="w2g-B4-7BF" customClass="OTMSegmentedControl">
                                 <rect key="frame" x="130" y="74" width="185" height="30"/>
@@ -47,52 +58,30 @@
                                 </connections>
                             </segmentedControl>
                             <view opaque="NO" contentMode="scaleToFill" id="cSI-Ty-HIV" customClass="OTMDetailSliderview">
-                                <rect key="frame" x="0.0" y="380" width="320" height="100"/>
+                                <rect key="frame" x="0.0" y="250" width="320" height="70"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" id="yCz-ce-iHJ">
-                                        <rect key="frame" x="12" y="27" width="71" height="60"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                        <color key="backgroundColor" red="0.90217391300000005" green="0.8903603336" blue="0.85491959510000004" alpha="1" colorSpace="calibratedRGB"/>
-                                    </imageView>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="F3b-37-QZN">
-                                        <rect key="frame" x="93" y="27" width="201" height="21"/>
+                                        <rect key="frame" x="78" y="19" width="201" height="21"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="iUl-4y-q6w">
-                                        <rect key="frame" x="93" y="48" width="201" height="19"/>
+                                        <rect key="frame" x="78" y="36" width="201" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="Kf6-Fe-hNX">
-                                        <rect key="frame" x="93" y="66" width="201" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="fyw-rm-Lup">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" size="button"/>
-                                        <state key="normal">
-                                            <color key="titleColor" red="0.19607843137254902" green="0.30980392156862746" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <state key="highlighted">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <connections>
-                                            <segue destination="Z5j-QU-uNU" kind="push" identifier="Details" id="ROJ-aE-inW"/>
-                                        </connections>
-                                    </button>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="Default_feature-image.png" id="yCz-ce-iHJ">
+                                        <rect key="frame" x="0.0" y="0.0" width="70" height="70"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <color key="backgroundColor" red="0.90217391300000005" green="0.8903603336" blue="0.85491959510000004" alpha="1" colorSpace="calibratedRGB"/>
+                                    </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="39d-EP-Yt2">
-                                        <rect key="frame" x="12" y="27" width="71" height="60"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="70" height="70"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                         <state key="normal">
@@ -106,24 +95,32 @@
                                             <action selector="showTreePhotoFullscreen:" destination="2" eventType="touchUpInside" id="FyD-ab-iwy"/>
                                         </connections>
                                     </button>
-                                    <imageView userInteractionEnabled="NO" contentMode="TopLeft" image="detail.png" id="IBN-1f-vqA">
-                                        <rect key="frame" x="301" y="50" width="16" height="18"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="fyw-rm-Lup">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" size="button"/>
+                                        <state key="normal">
+                                            <color key="titleColor" red="0.19607843137254902" green="0.30980392156862746" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <state key="highlighted">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <connections>
+                                            <segue destination="Z5j-QU-uNU" kind="push" identifier="Details" id="ROJ-aE-inW"/>
+                                        </connections>
+                                    </button>
+                                    <imageView userInteractionEnabled="NO" contentMode="center" image="Chevron_right.png" id="IBN-1f-vqA">
+                                        <rect key="frame" x="299" y="26" width="9" height="21"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </imageView>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="0.90907542610000003" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
-                            <searchBar contentMode="redraw" placeholder="Search Address or Location" id="tpv-GO-iyB" customClass="OTMSearchBar">
-                                <rect key="frame" x="226" y="93" width="320" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no"/>
-                                <connections>
-                                    <outlet property="delegate" destination="2" id="NLN-kZ-OGe"/>
-                                </connections>
-                            </searchBar>
                             <navigationBar contentMode="scaleToFill" id="Yxa-pc-A0G" customClass="OTMNavigationBar">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <color key="barTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <items>
                                     <navigationItem id="buS-y3-AQP">
                                         <barButtonItem key="leftBarButtonItem" image="gps_icon_14.png" id="aEH-bQ-xwn">
@@ -167,9 +164,8 @@
                                 <color key="backgroundColor" red="1" green="0.80794630629999997" blue="0.95198657659999997" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="First" image="first" id="7"/>
+                    <tabBarItem key="tabBarItem" title="First" image="TabBar_treemap.png" id="7"/>
                     <navigationItem key="navigationItem" title="Tree" id="Ka4-ap-ix0">
                         <barButtonItem key="leftBarButtonItem" title="Filter" id="8gu-xT-odz">
                             <connections>
@@ -182,7 +178,6 @@
                         <outlet property="addTreeHelpLabel" destination="WkD-Gf-Dze" id="v5o-zG-gmM"/>
                         <outlet property="addTreeHelpView" destination="YIP-Gg-DrZ" id="ThK-XW-ZLs"/>
                         <outlet property="address" destination="iUl-4y-q6w" id="bnH-IJ-YUU"/>
-                        <outlet property="dbh" destination="Kf6-Fe-hNX" id="BtX-Yy-F6q"/>
                         <outlet property="detailView" destination="cSI-Ty-HIV" id="psF-sh-2Xv"/>
                         <outlet property="filterStatusLabel" destination="rh9-R0-UUJ" id="jig-AY-HvF"/>
                         <outlet property="filterStatusView" destination="gMy-qL-BtE" id="88F-Am-EpQ"/>
@@ -214,7 +209,6 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <inset key="contentInset" minX="0.0" minY="90" maxX="0.0" maxY="0.0"/>
-                                <color key="separatorColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <sections/>
                                 <connections>
                                     <outlet property="dataSource" destination="Z5j-QU-uNU" id="tZ5-Eg-BRa"/>
@@ -274,7 +268,7 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <color key="backgroundColor" white="0.94083921370967749" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -324,17 +318,11 @@
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="1" green="0.90907542610000003" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="1Jc-w3-d6h" customClass="OTMButton">
-                                        <rect key="frame" x="20" y="15" width="280" height="37"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="1Jc-w3-d6h" customClass="OTMButton">
+                                        <rect key="frame" x="20" y="80" width="280" height="37"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                        <state key="normal" title="Species">
-                                            <color key="titleColor" red="0.90217391300000005" green="0.8903603336" blue="0.85491959510000004" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <state key="highlighted">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
+                                        <state key="normal" title="Species"/>
                                         <connections>
                                             <segue destination="v8c-v7-6H5" kind="push" identifier="pushSpecies" id="145-jK-ChU"/>
                                         </connections>
@@ -471,6 +459,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="Default.png" id="dh5-PK-ckz">
                                 <rect key="frame" x="0.0" y="-20" width="320" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -491,7 +480,7 @@
                     <tabBar key="tabBar" contentMode="scaleToFill" id="5">
                         <rect key="frame" x="0.0" y="431" width="320" height="49"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </tabBar>
                     <connections>
                         <segue destination="IOc-fB-8NC" kind="relationship" relationship="viewControllers" id="yrs-Ul-Kac"/>
@@ -575,14 +564,14 @@
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="kFieldDetailCurrentValueCellIdentifier" textLabel="Ig8-6N-hGz" style="IBUITableViewCellStyleDefault" id="cP2-oS-a8r">
-                                <rect key="frame" x="0.0" y="46" width="320" height="45"/>
+                                <rect key="frame" x="0.0" y="119" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cP2-oS-a8r" id="WNk-Cf-bPq">
-                                    <rect key="frame" x="10" y="1" width="300" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ig8-6N-hGz">
-                                            <rect key="frame" x="10" y="0.0" width="280" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -592,21 +581,21 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="kFieldDetailPendingEditCellIdentifier" textLabel="nNw-rv-dw3" detailTextLabel="y08-OM-1oN" style="IBUITableViewCellStyleSubtitle" id="wwu-AA-ZkQ">
-                                <rect key="frame" x="0.0" y="91" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="163" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wwu-AA-ZkQ" id="X6m-fP-hOI">
-                                    <rect key="frame" x="10" y="0.0" width="300" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nNw-rv-dw3">
-                                            <rect key="frame" x="10" y="2" width="38" height="22"/>
+                                            <rect key="frame" x="15" y="3" width="36" height="22"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         </label>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="y08-OM-1oN">
-                                            <rect key="frame" x="10" y="24" width="47" height="18"/>
+                                            <rect key="frame" x="15" y="25" width="50" height="17"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="0.50196078431372548" green="0.50196078431372548" blue="0.50196078431372548" alpha="1" colorSpace="calibratedRGB"/>
@@ -616,10 +605,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="kFieldDetailPendingLocationEditCellIdentifier" id="dUj-hV-tjR" customClass="OTMMapTableViewCell">
-                                <rect key="frame" x="0.0" y="135" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="207" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dUj-hV-tjR" id="3wA-Ko-c3f">
-                                    <rect key="frame" x="10" y="0.0" width="300" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -741,7 +730,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Profile" image="first" id="stQ-NQ-LQB"/>
+                    <tabBarItem key="tabBarItem" title="Profile" image="TabBar_profile.png" id="stQ-NQ-LQB"/>
                     <navigationItem key="navigationItem" id="qJc-Nq-vgF"/>
                     <connections>
                         <outlet property="loadingView" destination="MAs-fE-HdO" id="l5C-fw-FnP"/>
@@ -759,7 +748,7 @@
         <scene sceneID="f8G-zt-XN4">
             <objects>
                 <navigationController definesPresentationContext="YES" id="Bua-WS-BqB" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Tree List" image="recent_trees.png" id="jUG-J8-9UY"/>
+                    <tabBarItem key="tabBarItem" title="Tree List" image="TabBar_details.png" id="jUG-J8-9UY"/>
                     <navigationBar key="navigationBar" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="Zvq-9t-LHn" customClass="OTMNavigationBar">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -821,7 +810,7 @@
         <scene sceneID="SRH-GT-8eT">
             <objects>
                 <navigationController title="Profile" definesPresentationContext="YES" id="bif-JI-aQc" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Profile" image="profile.png" id="f7D-yS-5T9"/>
+                    <tabBarItem key="tabBarItem" title="Profile" image="TabBar_profile.png" id="f7D-yS-5T9"/>
                     <navigationBar key="navigationBar" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="8Lt-af-vsI" customClass="OTMNavigationBar">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -856,7 +845,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="About" image="about.png" id="Ci9-zh-qBm"/>
+                    <tabBarItem key="tabBarItem" title="About" image="TabBar_about.png" id="Ci9-zh-qBm"/>
                     <connections>
                         <outlet property="backgroundImageView" destination="LDK-Mi-JKH" id="A5H-LS-sor"/>
                         <outlet property="webView" destination="Wtz-GW-bdd" id="BS1-CP-gvl"/>
@@ -868,14 +857,14 @@
         </scene>
     </scenes>
     <resources>
+        <image name="Chevron_right.png" width="9" height="15"/>
         <image name="Default.png" width="320" height="480"/>
-        <image name="about.png" width="30" height="30"/>
-        <image name="detail.png" width="11" height="16"/>
-        <image name="first" width="16" height="16"/>
+        <image name="Default_feature-image.png" width="75" height="75"/>
+        <image name="TabBar_about.png" width="22" height="22"/>
+        <image name="TabBar_details.png" width="26" height="20"/>
+        <image name="TabBar_profile.png" width="22" height="22"/>
+        <image name="TabBar_treemap.png" width="18" height="26"/>
         <image name="gps_icon_14.png" width="14" height="14"/>
-        <image name="profile.png" width="30" height="30"/>
-        <image name="recent_trees.png" width="30" height="30"/>
-        <image name="tree_map.png" width="30" height="30"/>
     </resources>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
@@ -883,8 +872,8 @@
         <simulatedScreenMetrics key="destination"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="vdU-No-GUA"/>
-        <segue reference="ROJ-aE-inW"/>
         <segue reference="145-jK-ChU"/>
+        <segue reference="ROJ-aE-inW"/>
+        <segue reference="vdU-No-GUA"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/OpenTreeMap/src/OTM/Cells/OTMMapTableViewCell.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMMapTableViewCell.m
@@ -27,9 +27,16 @@
         self.mapView = [[MKMapView alloc] initWithFrame:CGRectMake(self.frame.origin.x, self.frame.origin.y, self.frame.size.width, kOTMMapTableViewCellHeight)];
         self.mapView.delegate = self;
 
-        self.mapView.layer.cornerRadius = 10.0;
-        self.mapView.layer.borderWidth = 1.0;
-        self.mapView.layer.borderColor = [[UIColor lightGrayColor] CGColor];
+        CALayer *borderTop = [CALayer layer];
+        borderTop.frame = CGRectMake(0.0f, 0.0f, mapView.frame.size.width, 0.5f);
+        borderTop.backgroundColor = [UIColor lightGrayColor].CGColor;
+        [mapView.layer addSublayer:borderTop];
+
+        CALayer *borderBottom = [CALayer layer];
+        borderBottom.frame = CGRectMake(0.0f, mapView.frame.origin.y, mapView.frame.size.width, 0.5f);
+        borderBottom.backgroundColor = [UIColor lightGrayColor].CGColor;
+        [mapView.layer addSublayer:borderBottom];
+
         self.backgroundView = self.mapView;
 
         // The mini map in the table cell is never interactive since a small scrolling map view
@@ -82,13 +89,13 @@
     if (!annotation) {
         annotation = [[MKPointAnnotation alloc] init];
     }
-    
+
     [mapView removeAnnotation:annotation];
-    
+
     // Set a small latitude delta to zoom the map in close to the point
     MKCoordinateSpan span = MKCoordinateSpanMake([[OTMEnvironment sharedEnvironment] detailLatSpan], 0.00);
     [mapView setRegion:MKCoordinateRegionMake(center, span) animated:NO];
-    
+
     annotation.coordinate = center;
     [mapView addAnnotation:annotation];
 }

--- a/OpenTreeMap/src/OTM/OTMAppDelegate.m
+++ b/OpenTreeMap/src/OTM/OTMAppDelegate.m
@@ -78,6 +78,7 @@
 -(void)changeEnvironment:(NSNotification *)note {
     OTMEnvironment *env = note.object;
     self.window.tintColor = env.primaryColor;
+    self.window.backgroundColor = [UIColor whiteColor];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMButton.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMButton.m
@@ -36,9 +36,7 @@
 }
 
 -(void)loadTheme {
-    [self setBackgroundColor:[UIColor colorWithPatternImage:[[OTMEnvironment sharedEnvironment] buttonImage]]]; 
 
-    self.titleLabel.textColor = [[OTMEnvironment sharedEnvironment] buttonTextColor];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMDetailBoxView.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMDetailBoxView.m
@@ -19,10 +19,7 @@
 @implementation OTMDetailBoxView
 
 -(void)loadTheme {
-    fadeAtBottom = YES;
-    self.layer.shadowColor = [[UIColor blackColor] CGColor];
-    self.layer.shadowOffset = CGSizeMake(0.0f, 1.0f);
-    self.layer.shadowOpacity = 0.3;
+
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMDetailSliderview.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMDetailSliderview.m
@@ -36,52 +36,6 @@
     return self;
 }
 
--(void)loadTheme {
-    fadeAtBottom = NO;
-    self.layer.shadowColor = [[UIColor blackColor] CGColor];
-    self.layer.shadowOffset = CGSizeMake(0.0f, -1.0f);
-    self.layer.shadowOpacity = 0.3;
-}
-
-- (void)drawRect:(CGRect)rect
-{    
-    float pct = .90;   
-    float height = self.frame.size.height;
-    
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-
-    /// Main Gradient
-    float color[] = { pct, pct, pct, 1.0 };
-    CGColorRef startColor = [[UIColor whiteColor] CGColor];
-    CGColorRef endColor = CGColorCreate(colorSpace, color);
-
-    float locations[] = {0.0, 1.0};
-    const void* colors[] = { startColor, endColor };
-    CFArrayRef colorArray = CFArrayCreate(NULL, colors, 2, NULL);
-    CGGradientRef gradient = CGGradientCreateWithColors(colorSpace,
-                                                        colorArray, 
-                                                        locations);
-        
-    CGFloat fadeOffset = fadeAtBottom ? 0 : 15;
-    CGRect gframe = CGRectMake(0, fadeOffset, self.frame.size.width, height - 15);
-    
-    CGContextSetFillColorWithColor(context, [[self backgroundColor] CGColor]);
-    CGContextFillRect(context, gframe);    
-    
-    CGContextSaveGState(context);
-    CGContextAddRect(context,
-                     gframe);
-    CGContextClip(context);
-    CGContextDrawLinearGradient(context, gradient, 
-                                CGPointMake(CGRectGetMidX(gframe), fadeOffset),
-                                CGPointMake(CGRectGetMidX(gframe), gframe.size.height + fadeOffset),
-                                0);
-    
-    CGContextRestoreGState(context);
-
-    CFRelease(colorArray);
-    CGColorSpaceRelease(colorSpace);
-}
+-(void)loadTheme {}
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMFilterStatusView.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMFilterStatusView.m
@@ -38,10 +38,7 @@
 
 - (void)loadTheme
 {
-    self.layer.shadowColor = [[UIColor blackColor] CGColor];
-    self.layer.shadowOffset = CGSizeMake(0.0f, -1.0f);
-    self.layer.shadowOpacity = 0.3;
-    self.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"filter_status_bg"]];
+
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMHelpView.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMHelpView.m
@@ -39,10 +39,7 @@
 
 - (void)loadTheme
 {
-    self.layer.shadowColor = [[UIColor blackColor] CGColor];
-    self.layer.shadowOffset = CGSizeMake(0.0f, 1.0f);
-    self.layer.shadowOpacity = 0.3;
-    self.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"add_help_bg"]];
+
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMTableView.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMTableView.m
@@ -36,7 +36,6 @@
 }
 
 -(void)loadTheme {
-    [self setBackgroundColor:[[OTMEnvironment sharedEnvironment] viewBackgroundColor]];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Theme/OTMView.m
+++ b/OpenTreeMap/src/OTM/Theme/OTMView.m
@@ -36,7 +36,7 @@
 }
 
 -(void)loadTheme {
-    [self setBackgroundColor:[[OTMEnvironment sharedEnvironment] viewBackgroundColor]];
+
 }
 
 @end


### PR DESCRIPTION
Removing gradients and rearranging UI to match Mike T's mockups.

I added a reference to the 4-inch launch image so that the app can start up non-letterboxed on a 4-inch screen.

Mike T has updated the mobile skin repository with new image names, requiring complementary updates to the application.
