### PR TITLE
Restore full page photo view on map page

### DIFF
--- a/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
+++ b/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
@@ -61,6 +61,21 @@
                                 <rect key="frame" x="0.0" y="250" width="320" height="70"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="39d-EP-Yt2">
+                                        <rect key="frame" x="0.0" y="0.0" width="70" height="70"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <state key="normal">
+                                            <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <state key="highlighted">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="showTreePhotoFullscreen:" destination="2" eventType="touchUpInside" id="FyD-ab-iwy"/>
+                                        </connections>
+                                    </button>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="F3b-37-QZN">
                                         <rect key="frame" x="78" y="19" width="201" height="21"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -80,23 +95,8 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" red="0.90217391300000005" green="0.8903603336" blue="0.85491959510000004" alpha="1" colorSpace="calibratedRGB"/>
                                     </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="39d-EP-Yt2">
-                                        <rect key="frame" x="0.0" y="0.0" width="70" height="70"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                        <state key="normal">
-                                            <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <state key="highlighted">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="showTreePhotoFullscreen:" destination="2" eventType="touchUpInside" id="FyD-ab-iwy"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="fyw-rm-Lup">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                                        <rect key="frame" x="69" y="0.0" width="251" height="70"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="boldSystem" size="button"/>
                                         <state key="normal">
@@ -655,10 +655,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" id="gGa-rZ-8ES">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            </imageView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" minimumZoomScale="0.125" maximumZoomScale="4" id="a2K-iz-UpQ">
+                                <rect key="frame" x="0.0" y="0.0" width="326" height="480"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="TopLeft" id="gGa-rZ-8ES">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    </imageView>
+                                </subviews>
+                            </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
@@ -667,6 +673,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="imageView" destination="gGa-rZ-8ES" id="yt2-TL-OQb"/>
+                        <outlet property="scrollView" destination="a2K-iz-UpQ" id="AMO-g2-Gvp"/>
                         <outlet property="view" destination="fZo-Zk-WWS" id="EJh-59-zE5"/>
                     </connections>
                 </viewController>
@@ -856,7 +863,7 @@
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
         <segue reference="ROJ-aE-inW"/>
+        <segue reference="vdU-No-GUA"/>
         <segue reference="Lek-fL-nUD"/>
-        <segue reference="gQW-vu-Tty"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.h
@@ -19,6 +19,7 @@
 @interface OTMImageViewController : UIViewController
 
 @property (nonatomic,strong) IBOutlet UIImageView *imageView;
+@property (nonatomic,strong) IBOutlet UIScrollView *scrollView;
 
 - (void)loadImage:(NSString *)url;
 

--- a/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.m
@@ -21,35 +21,63 @@
 
 @end
 
-@implementation OTMImageViewController 
+@implementation OTMImageViewController
 
-- (void)loadImage:(NSString *)url {
+- (void)loadImage:(NSString *)url
+{
+    self.imageView.image = nil;
     [[AZWaitingOverlayController sharedController] showOverlayWithTitle:@"Downloading"];
-    [[[OTMEnvironment sharedEnvironment] api] getTreeImage:url callback:^(UIImage *image, NSError *error) {
-        if (error) {
-            UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Error"
-                                                                message:@"Could not download image"
-                                                               delegate:nil
-                                                        cancelButtonTitle:@"OK"
-                                                      otherButtonTitles:nil];
-            [alertView show];
-        } else {
-            self.imageView.image = image;
-        }
-        [[AZWaitingOverlayController sharedController] hideOverlay];
-    }];
+
+    dispatch_async(dispatch_get_global_queue(0,0), ^{
+        NSData *imageData = [[NSData alloc] initWithContentsOfURL:[NSURL URLWithString:url]];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[AZWaitingOverlayController sharedController] hideOverlay];
+            if (imageData) {
+                UIImage *image = [UIImage imageWithData: imageData];
+                self.imageView.image = image;
+                self.scrollView.contentSize = self.imageView.image.size;
+                self.imageView.frame = CGRectMake(0, 0, self.imageView.image.size.width, self.imageView.image.size.height);
+                self.scrollView.minimumZoomScale = self.scrollView.frame.size.width / image.size.width;
+                self.scrollView.zoomScale = self.scrollView.frame.size.width / image.size.width;
+            } else {
+                NSLog(@"Failed to load photo with url %@", url);
+                // TODO: Log more info about _why_ the image reqest failed
+                UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Error"
+                                                                    message:@"Could not download image"
+                                                                   delegate:nil
+                                                          cancelButtonTitle:@"OK"
+                                                          otherButtonTitles:nil];
+                [alertView show];
+            }
+        });
+    });
+}
+
+- (void)handleImageDoubleTap:(id)thing {
+    CGFloat zoomScale = self.scrollView.frame.size.width / self.imageView.image.size.width;
+    [self.scrollView setZoomScale:zoomScale animated:YES];
 }
 
 - (void)viewDidLoad
 {
+    self.imageView.userInteractionEnabled = YES;
+    self.scrollView.delegate = (id)self;
+
+    UITapGestureRecognizer *imageDoubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleImageDoubleTap:)];
+    imageDoubleTap.numberOfTapsRequired = 2;
+    [self.imageView addGestureRecognizer:imageDoubleTap];
+
     [super viewDidLoad];
-	// Do any additional setup after loading the view.
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView{
+    return [self imageView];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -135,4 +135,7 @@
 
 - (void)updateEnvironmentWithDictionary:(NSDictionary *)dict;
 
+
+- (NSString *)absolutePhotoUrlFromPhotoUrl:(NSString *)url;
+
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -400,6 +400,19 @@
     }
 }
 
+// Photo urls returned from the API may be relative to the application, or absolute S3 urls.
+- (NSString *)absolutePhotoUrlFromPhotoUrl:(NSString *)photoUrl {
+    if (![photoUrl hasPrefix:@"http"]) {
+        NSURL *url = [NSURL URLWithString:self.baseURL];
+        NSString *host = [url host];
+        NSString *scheme = [url scheme];
+        NSNumber *port = [url port];
+        return [NSString stringWithFormat:@"%@://%@:%@%@", scheme, host, port, photoUrl];
+    } else {
+        return photoUrl;
+    }
+}
+
 //
 // Functions from DB5
 // https://github.com/quartermaster/DB5/blob/7e41cef54e7ae9d3e97c2f8f23fc5cf14df72114/Source/VSTheme.m

--- a/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.h
+++ b/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.h
@@ -27,4 +27,6 @@
  */
 +(CLLocationCoordinate2D)getCoordinateFromDictionary:(NSDictionary *)dict;
 
++(NSString *)getLatestPhotoUrlInDictionary:(NSDictionary *)dict;
+
 @end

--- a/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.m
+++ b/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.m
@@ -37,5 +37,14 @@
     return CLLocationCoordinate2DMake(lat, lng);
 }
 
++(NSString *)getLatestPhotoUrlInDictionary:(NSDictionary *)dict
+{
+    NSArray* photos = [dict objectForKey:@"photos"];
+    if (photos && [photos isKindOfClass:[NSArray class]] && [photos count] > 0) {
+        return [[OTMEnvironment sharedEnvironment] absolutePhotoUrlFromPhotoUrl:[[photos lastObject] objectForKey:@"image"]];
+    } else {
+        return nil;
+    }
+}
 
 @end


### PR DESCRIPTION
Changes to the API response schema broke photo viewing. While fixing it
I took the opertunity to refactor photo loading logic so it could be
shared and added a scroll view and gesture recognizer to the image view
controller so it more closely recreates iOS native photo zooming and scrolling.
