### PR TITLE
Fix georev update when moving a plot

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -405,12 +405,13 @@
                     [[AZWaitingOverlayController sharedController] hideOverlay];
 
                     if (err == nil) {
+                        self.data = [json mutableDeepCopy];
+                        [self pushImageData:pendingImageData newTree:NO];
                         [[OTMEnvironment sharedEnvironment] setGeoRev:data[@"geoRevHash"]];
-                        if (err == nil) {
-                            [self pushImageData:pendingImageData newTree:NO];
-                            self.data = [json mutableDeepCopy];
-                            [delegate viewController:self editedTree:(NSDictionary *)data withOriginalLocation:originalLocation originalData:originalData];
-                        }
+                        [delegate viewController:self
+                                      editedTree:(NSDictionary *)data
+                            withOriginalLocation:originalLocation
+                                    originalData:originalData];
                     } else {
                         NSLog(@"Error updating tree: %@\n %@", err, data);
                         [[[UIAlertView alloc] initWithTitle:nil


### PR DESCRIPTION
There was an "off by one" problem because the old georev was being posted as a notification before it was updated with the JSON response.
