### PR TITLE
New field grouping

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -583,16 +583,12 @@
         // when it is in edit mode, so the section labels no longer apply.
         return nil;
     } else {
-        NSString *title = nil;
-        NSDictionary *fieldSectionDict = [[[OTMEnvironment sharedEnvironment] fieldSections] objectAtIndex:section];
-        if (fieldSectionDict) {
-            if ([fieldSectionDict objectForKey:@"label"]) {
-                if (![(NSString *)[fieldSectionDict objectForKey:@"label"] isEqualToString:@""]) {
-                    title = [fieldSectionDict objectForKey:@"label"];
-                }
-            }
+        NSString *title = [[[OTMEnvironment sharedEnvironment] sectionTitles] objectAtIndex:section];
+        if (title != nil && ![title isEqualToString:@""]) {
+            return title;
+        } else {
+            return nil;
         }
-        return title;
     }
 }
 

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -97,7 +97,7 @@
 @property (nonatomic, strong) UIImage *buttonImage;
 @property (nonatomic, strong) UIColor *buttonTextColor;
 @property (nonatomic, assign) BOOL pendingActive;
-@property (nonatomic, strong) NSArray* fieldSections;
+@property (nonatomic, strong) NSArray* sectionTitles;
 @property (nonatomic, strong) NSArray* fields;
 @property (nonatomic, strong) NSArray* ecoFields;
 @property (nonatomic, strong) NSArray* filts;

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -174,6 +174,7 @@
     self.instanceId = [dict objectForKey:@"id"];
     self.geoRev = [dict objectForKey:@"geoRevHash"];
     self.fields = [self fieldsFromDict:[dict objectForKey:@"fields"] orderedAndGroupedByDictArray:[dict objectForKey:@"field_key_groups"]];
+    self.sectionTitles = [self sectionTitlesFromDictArray:[dict objectForKey:@"field_key_groups"]];
     self.config = [dict objectForKey:@"config"];
 
     NSDictionary *missingAndStandardFilters = [dict objectForKey:@"search"];
@@ -356,6 +357,27 @@
                                                                  label:displayField
                                                              formatter:fmt]];
     }
+}
+
+- (NSArray *)sectionTitlesFromDictArray:(NSArray *)fieldKeyGroups {
+    NSMutableArray *sectionTitles = [NSMutableArray array];
+
+    // The first section is a mini map with no heading
+    [sectionTitles addObject:@""];
+
+    [fieldKeyGroups enumerateObjectsUsingBlock:^(id keyGroupDict, NSUInteger idx, BOOL *stop) {
+        NSString *header = [keyGroupDict objectForKey:@"header"];
+        if (header != nil) {
+            [sectionTitles addObject:header];
+        } else {
+            [sectionTitles addObject:@""];
+        }
+    }];
+
+    // Eco is always shown at the bottom
+    [sectionTitles addObject:@"Yearly Ecosystem Services"];
+
+    return sectionTitles;
 }
 
 - (NSArray *)fieldsFromDict:(NSDictionary *)fields orderedAndGroupedByDictArray:(NSArray *)fieldKeyGroups {


### PR DESCRIPTION
The instance API has been updated to return all fields visible to the current user and an array of field sections defining the explicit grouping and ordering of fields in the mobile apps.

The fields the tree detail table view now use the two-line "subheading" style, so we have more room for detailed field labels.

I elimitated the no-longer-used fieldSections property on the Environment and replaced it an array of section titles parsed from the instance API response.
