### PR TITLE
Add support for static tile query string args

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -476,6 +476,11 @@
         urlSfx = [urlSfx stringByAppendingFormat:@"&q=%@", filter];
     }
 
+    if ([[OTMEnvironment sharedEnvironment] tileQueryStringAdditionalArguments]) {
+        urlSfx = [NSString stringWithFormat:@"%@&%@", urlSfx,
+                  [[OTMEnvironment sharedEnvironment] tileQueryStringAdditionalArguments]];
+    }
+
     NSString *host = env.host;
     NSString *url = [host stringByAppendingString:urlSfx];
 

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -103,6 +103,7 @@
 @property (nonatomic, strong) NSArray* filts;
 @property (nonatomic, assign) BOOL useOtmGeocoder;
 @property (nonatomic, assign) double searchRegionRadiusInMeters;
+@property (nonatomic, strong) NSString *tileQueryStringAdditionalArguments;
 @property (nonatomic, assign) double nearbyTreeRadiusInMeters;
 @property (nonatomic, assign) double recentEditsRadiusInMeters;
 @property (nonatomic, assign) float splashDelayInSeconds;

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -105,6 +105,8 @@
 
     [self setSearchRegionRadiusInMeters:[[mapView valueForKey:@"SearchRegionRadiusInMeters"] doubleValue]];
 
+    [self setTileQueryStringAdditionalArguments:[mapView valueForKey:@"TileQueryStringAdditionalArguments"]];
+
     [self setNearbyTreeRadiusInMeters:[[implementation valueForKey:@"NearbyTreeRadiusInMeters"] doubleValue]];
     if (self.nearbyTreeRadiusInMeters == 0.0) {
         self.nearbyTreeRadiusInMeters = 300.0; // 300 meters is a guess at average city block size


### PR DESCRIPTION
This application does not support non-plot map features, so we need to prevent including dots for the non-plot map features on the map tiles. The tiler supports this with a show= query string argument, so I have added an OTMEnvironment setting that is appended to the tile url template.

Closes #91 
