### PR TITLE
Allow clearing saved keychain data

### DIFF
--- a/OpenTreeMap/src/AZ/AZKeychainItemWrapper.m
+++ b/OpenTreeMap/src/AZ/AZKeychainItemWrapper.m
@@ -166,11 +166,14 @@
 
 - (void)setObject:(id)inObject forKey:(id)key 
 {
-    if (inObject == nil) return;
     id currentObject = [keychainItemData objectForKey:key];
     if (![currentObject isEqual:inObject])
     {
-        [keychainItemData setObject:inObject forKey:key];
+        if (inObject == nil) {
+            [keychainItemData removeObjectForKey:key];
+        } else {
+            [keychainItemData setObject:inObject forKey:key];
+        }
         [self writeToKeychain];
     }
 }

--- a/OpenTreeMap/src/AZ/AZUser.m
+++ b/OpenTreeMap/src/AZ/AZUser.m
@@ -37,7 +37,9 @@
 
 -(void)logout {
     [self setUsername:nil];
-    [self setPassword:nil];
+    // Keychain does not allow v_Data (the password) to be nil,
+    // so we set it to the empty string, which is an invalid password
+    [self setPassword:@""];
 }
 
 @end


### PR DESCRIPTION
Logging out of the application would not "stick" because the keychain wrapper did not allow clearing values.

Closes #96 
