### PR TITLE
Omit port from tile URL template when it is 80

### DIFF
--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -138,8 +138,9 @@
     NSURL *aurl = [NSURL URLWithString:[self baseURL]];
     AZHttpRequest* req = [[AZHttpRequest alloc] initWithURL:[self baseURL]];
     req.headers = headers;
-    self.host = [NSString stringWithFormat:@"%@://%@:%@",
-                          [aurl scheme],[aurl host],[aurl port]];
+    NSString *portString = [aurl port] ? [NSString stringWithFormat:@":%@", [aurl port]] : @"";
+    self.host = [NSString stringWithFormat:@"%@://%@%@",
+                          [aurl scheme],[aurl host], portString];
 
     AZHttpRequest* reqraw = [[AZHttpRequest alloc] initWithURL:self.baseURL];
     req.headers = headers;


### PR DESCRIPTION
I was seeing problems with tile requests due to the string "(null)" being included in the url when the host does not specify a port.
