### PR TITLE
Use the label from the actual benefit

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
@@ -97,7 +97,7 @@ ABSTRACT_METHOD
 @property (nonatomic,strong) OTMBenefitsTableViewCell *cell;
 @property (nonatomic,assign) NSInteger *index;
 
--(id)initWithLabel:(NSString *)label index:(NSInteger) idx;
+-(id)initWithIndex:(NSInteger) idx;
 
 @end
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -114,13 +114,12 @@
 @implementation OTMBenefitsDetailCellRenderer
 
 
--(id)initWithLabel:(NSString *)label index:(NSInteger)idx {
+-(id)initWithIndex:(NSInteger)idx {
     self = [super initWithDataKey:nil];
 
     if (self) {
         _cell = [OTMBenefitsTableViewCell loadFromNib];
         self.cellHeight = _cell.frame.size.height;
-        self.cell.benefitName.text = label;
         self.index = idx;
     }
 
@@ -131,6 +130,8 @@
     NSDictionary *allBenefits = [data objectForKey:@"benefits"];
     NSArray *plotBenefits = [allBenefits objectForKey:@"plot"];
     NSDictionary *benefit = [plotBenefits objectAtIndex:self.index];
+
+    self.cell.benefitName.text = benefit[@"label"];
 
     NSString *value = [benefit objectForKey:@"value"];
     NSString *unit = [benefit objectForKey:@"unit"];

--- a/OpenTreeMap/src/OTM/Controllers/OTMFieldDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFieldDetailViewController.m
@@ -430,6 +430,7 @@
         } else {
             [[AZWaitingOverlayController sharedController] hideOverlay];
             NSLog(@"Error approving pending edit: %@", [error description]);
+
             [UIAlertView showAlertWithTitle:nil message:@"There was a problem approving the pending edit." cancelButtonTitle:@"OK"otherButtonTitle:nil callback:nil];
 
         }

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -414,7 +414,7 @@
         [benefits enumerateObjectsUsingBlock:^(NSDictionary *fieldDict, NSUInteger idx, BOOL *stop) {
             // Currently, we create the same type of cell renderer without regard to
             // any of the field details
-            [fieldArray addObject:[[OTMBenefitsDetailCellRenderer alloc] initWithLabel:[fieldDict objectForKey:@"label"] index:idx]];
+            [fieldArray addObject:[[OTMBenefitsDetailCellRenderer alloc] initWithIndex:idx]];
         }];
         // To be consistant with the editable fields, the eco fields are wrapped in a containing
         // array that represents the field group. This may be useful


### PR DESCRIPTION
Previously they were separated between env loading and the actual
rendering process.

Fixes #120
