### PR TITLE
Log signed URLs

### DIFF
--- a/OpenTreeMap/src/AZ/AZHttpRequest.m
+++ b/OpenTreeMap/src/AZ/AZHttpRequest.m
@@ -332,7 +332,7 @@
 
     #ifdef DEBUG
     [self logHttpRequest:request];
-    NSLog(@"Signature: %@", sig);
+    NSLog(@"Signed Url: %@&signature=%@", url, sig);
     #endif
 
     if (synchronous) {


### PR DESCRIPTION
This eases the testing of API calls, allowing for easy copy paste to the browser or terminal.
