### PR TITLE
Add in EULA view after registering

### DIFF
--- a/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
+++ b/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		D70D98E916D28F7600795F84 /* OTMImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D70D98E816D28F7600795F84 /* OTMImageViewController.m */; };
 		D72BF6661517830A00AB6664 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D72BF6651517830A00AB6664 /* Security.framework */; };
 		D74B1FCB18B78EA5006BABE2 /* OTMFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = D74B1FCA18B78EA5006BABE2 /* OTMFormatter.m */; };
+		D7B4E1CF1906FB280028E3B1 /* OTMEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D7B4E1CE1906FB280028E3B1 /* OTMEULAViewController.m */; };
 		D7C990201518C8670094770C /* libASI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C9901F1518C8670094770C /* libASI.a */; };
 		D7C990231518C87E0094770C /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C990221518C87E0094770C /* CFNetwork.framework */; };
 		D7C990251518C8890094770C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C990241518C8890094770C /* SystemConfiguration.framework */; };
@@ -363,6 +364,8 @@
 		D72BF6651517830A00AB6664 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		D74B1FC918B78EA5006BABE2 /* OTMFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMFormatter.h; sourceTree = "<group>"; };
 		D74B1FCA18B78EA5006BABE2 /* OTMFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMFormatter.m; sourceTree = "<group>"; };
+		D7B4E1CD1906FB280028E3B1 /* OTMEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMEULAViewController.h; sourceTree = "<group>"; };
+		D7B4E1CE1906FB280028E3B1 /* OTMEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMEULAViewController.m; sourceTree = "<group>"; };
 		D7C9901F1518C8670094770C /* libASI.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libASI.a; path = "../lib/ASI/build/Release-iphoneos/libASI.a"; sourceTree = "<group>"; };
 		D7C990221518C87E0094770C /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		D7C990241518C8890094770C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -618,6 +621,8 @@
 				646086BE160CFB6700A1458B /* OTMTreeDetailViewController.m */,
 				6470BEEB18E0A8C700C56A8F /* OTMViewController.h */,
 				6470BEEC18E0A8C700C56A8F /* OTMViewController.m */,
+				D7B4E1CD1906FB280028E3B1 /* OTMEULAViewController.h */,
+				D7B4E1CE1906FB280028E3B1 /* OTMEULAViewController.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -970,6 +975,7 @@
 				64608719160CFB6700A1458B /* OTMTreeDetailViewController.m in Sources */,
 				6460871A160CFB6700A1458B /* OTMAddTreeAnnotationView.m in Sources */,
 				6460871B160CFB6700A1458B /* OTMAPI.m in Sources */,
+				D7B4E1CF1906FB280028E3B1 /* OTMEULAViewController.m in Sources */,
 				6460871C160CFB6700A1458B /* OTMAppDelegate.m in Sources */,
 				6460871D160CFB6700A1458B /* OTMEnvironment.m in Sources */,
 				6460871F160CFB6700A1458B /* OTMLoginManager.m in Sources */,

--- a/OpenTreeMap/resources/LoginStoryboard.storyboard
+++ b/OpenTreeMap/resources/LoginStoryboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="yby-6X-duV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="yby-6X-duV">
     <dependencies>
         <deployment defaultVersion="1280" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>
     <scenes>
         <!--Login View Controller - Login-->
@@ -212,7 +212,7 @@
                     <navigationItem key="navigationItem" title="Create Profile" id="6Uz-Gy-6Uu">
                         <barButtonItem key="rightBarButtonItem" systemItem="done" id="Fma-Oh-J3E">
                             <connections>
-                                <action selector="createNewUser:" destination="EHZ-o9-hUZ" id="SaL-bt-Jpv"/>
+                                <action selector="validateAndShowEULA:" destination="EHZ-o9-hUZ" id="lEk-a6-Tkb"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -228,11 +228,48 @@
                         <outlet property="username" destination="83T-RB-vAP" id="N34-ht-Dzx"/>
                         <outlet property="verifyPassword" destination="e39-YE-7jE" id="9ag-3r-bnR"/>
                         <outlet property="view" destination="rdP-k2-Kth" id="K5d-Uj-3sW"/>
+                        <segue destination="4vG-ZF-nSf" kind="push" identifier="eula" id="9Dp-cH-qo7"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lDl-L0-tWs" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="788" y="-832"/>
+            <point key="canvasLocation" x="887" y="-866"/>
+        </scene>
+        <!--View Controller - Terms of Service-->
+        <scene sceneID="XYL-el-r2F">
+            <objects>
+                <viewController storyboardIdentifier="EULAController" id="4vG-ZF-nSf" customClass="OTMEULAViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="I45-WE-C1e">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <webView contentMode="scaleToFill" keyboardDisplayRequiresUserAction="NO" id="tli-yx-sTv">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            </webView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Terms of Service" id="J7u-h7-v1c">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="irt-cG-1VM">
+                            <connections>
+                                <action selector="rejectEULA:" destination="4vG-ZF-nSf" id="hLU-f4-wTQ"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Accept" id="ho5-GL-PfI">
+                            <connections>
+                                <action selector="acceptEULA:" destination="4vG-ZF-nSf" id="MwV-Ma-VJV"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="webview" destination="tli-yx-sTv" id="n8Q-uN-zFk"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MMi-Fc-5Rr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1323" y="-767"/>
         </scene>
         <!--Password Reset View Controller - Reset Password-->
         <scene sceneID="1ld-VF-WiR">

--- a/OpenTreeMap/src/OTM/Controllers/OTMEULAViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMEULAViewController.h
@@ -1,0 +1,22 @@
+//
+//  OTMEULAViewController.h
+//  OpenTreeMap
+//
+//  Created by Adam Hinz on 4/22/14.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import "OTMRegistrationViewController.h"
+
+@interface OTMEULAViewController : UIViewController
+
+@property (nonatomic) BOOL loaded;
+@property (nonatomic, strong) OTMRegistrationViewController *regController;
+@property (nonatomic, strong) IBOutlet UIWebView *webview;
+
+-(void)loadWebview;
+-(IBAction)acceptEULA:(id)sender;
+-(IBAction)rejectEULA:(id)sender;
+
+@end

--- a/OpenTreeMap/src/OTM/Controllers/OTMEULAViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMEULAViewController.m
@@ -1,0 +1,64 @@
+//
+//  OTMEULAViewController.m
+//  OpenTreeMap
+//
+//  Created by Adam Hinz on 4/22/14.
+//
+//
+
+#import "OTMEULAViewController.h"
+
+@interface OTMEULAViewController ()
+
+@end
+
+@implementation OTMEULAViewController
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        [self loadWebview];
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    [self loadWebview];
+}
+
+- (void)loadWebview {
+    if (!self.loaded) {
+        self.webview.delegate = self;
+        [self.webview loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://www.opentreemap.org/terms-of-service/"]]];
+        self.loaded = YES;
+    }
+}
+
+- (void)webViewDidFinishLoad:(UIWebView *)webView {
+    [self.webview stringByEvaluatingJavaScriptFromString:@"document.getElementsByClassName('header')[0].remove()"];
+    [self.webview stringByEvaluatingJavaScriptFromString:@"document.getElementsByClassName('navbar')[0].remove()"];
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+-(IBAction)acceptEULA:(id)sender {
+    [self.regController createNewUser];
+}
+
+-(IBAction)rejectEULA:(id)sender {
+    [self.navigationController popViewControllerAnimated:YES];
+
+}
+
+-(void)dealloc {
+    self.webview.delegate = nil;
+}
+
+@end

--- a/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.h
@@ -18,21 +18,26 @@
 #import "OTMValidator.h"
 #import "OTMPictureTaker.h"
 
+@class OTMEULAViewController;
+
 @interface OTMRegistrationViewController : OTMScrollAwareViewController<UIActionSheetDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
 @property (nonatomic,readonly) OTMValidator *validator;
 @property (nonatomic,readonly) OTMPictureTaker *pictureTaker;
 
-@property (nonatomic,strong) IBOutlet UITextField *email; 
-@property (nonatomic,strong) IBOutlet UITextField *password; 
-@property (nonatomic,strong) IBOutlet UITextField *verifyPassword; 
-@property (nonatomic,strong) IBOutlet UITextField *username; 
-@property (nonatomic,strong) IBOutlet UITextField *firstName; 
-@property (nonatomic,strong) IBOutlet UITextField *lastName; 
+@property (nonatomic,strong) IBOutlet UITextField *email;
+@property (nonatomic,strong) IBOutlet UITextField *password;
+@property (nonatomic,strong) IBOutlet UITextField *verifyPassword;
+@property (nonatomic,strong) IBOutlet UITextField *username;
+@property (nonatomic,strong) IBOutlet UITextField *firstName;
+@property (nonatomic,strong) IBOutlet UITextField *lastName;
 @property (nonatomic,strong) IBOutlet UITextField *zipCode;
-@property (nonatomic,strong) IBOutlet UIImageView *profileImage; 
+@property (nonatomic,strong) IBOutlet UIImageView *profileImage;
 @property (nonatomic,strong) IBOutlet UIButton *changeProfilePic;
+@property (nonatomic,strong) OTMEULAViewController *eulaController;
 
 -(IBAction)getPicture:(id)sender;
+-(IBAction)validateAndShowEULA:(id)sender;
+-(void)createNewUser;
 
 @end

--- a/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
@@ -15,6 +15,9 @@
 
 #import "OTMRegistrationViewController.h"
 #import "OTMAppDelegate.h"
+#import "OTMEnvironment.h"
+#import "UIAlertView+Blocks.h"
+#import "OTMEULAViewController.h"
 
 @interface OTMRegistrationViewController ()
 
@@ -95,7 +98,15 @@
      }];
 }
 
--(IBAction)createNewUser:(id)sender {
+-(IBAction)validateAndShowEULA:(id)sender {
+    if ([self.validator executeValidationsAndAlertWithViewController:self]) {
+        [self.navigationController pushViewController:self.eulaController animated:YES];
+    } else {
+        [self.navigationController popToViewController:self animated:YES];
+    }
+}
+
+-(void)createNewUser {
     if ([self.validator executeValidationsAndAlertWithViewController:self]) {
         OTMUser *user = [[OTMUser alloc] init];
         user.keychain = [SharedAppDelegate keychain];
@@ -124,12 +135,14 @@
                                            delegate:nil
                                   cancelButtonTitle:@"OK"
                                   otherButtonTitles:nil] show];
+                [self.navigationController popToViewController:self animated:YES];
             } else {
                 [[[UIAlertView alloc] initWithTitle:@"Registration Failed"
                                            message:@"A server problem prevented your registration from completing. Please try again later."
                                           delegate:nil
                                  cancelButtonTitle:@"OK"
                                   otherButtonTitles:nil] show];
+                [self.navigationController popToViewController:self animated:YES];
             }
         }];
     }
@@ -149,7 +162,7 @@
             // touch events do not register
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (btnIdx == 0) { // NO
-                    [self createNewUser:nil];
+                    [self validateAndShowEULA:nil];
                 } else {
                     [pictureTaker getPictureInViewController:self
                                                     callback:^(UIImage *image)
@@ -181,6 +194,14 @@
 {
     [super viewDidLoad];
 
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"LoginStoryboard" bundle:nil];
+
+    self.eulaController =
+        [storyboard instantiateViewControllerWithIdentifier:@"EULAController"];
+
+    self.eulaController.regController = self;
+    [self.eulaController view];
+
     if (validator == nil) {
         validator = [[OTMValidator alloc] initWithValidations:[OTMRegistrationViewController validations]];
     }
@@ -201,5 +222,6 @@
 {
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
+
 
 @end


### PR DESCRIPTION
Currently this view grabs from
https://www.opentreemap.org/terms-of-service/ and trims out some of that
fat that is left using javascript.

We may want to reconsider how the workflow moves as well. Right now we
preload all of the content via the registration view and use manual
"push/pop" nav calls.
