### PR TITLE
Reference local images in Xcode project

### DIFF
--- a/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
+++ b/OpenTreeMap/OpenTreeMap.xcodeproj/project.pbxproj
@@ -10,8 +10,6 @@
 		64318CD31551E27D001C827F /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C990221518C87E0094770C /* CFNetwork.framework */; };
 		6452955218D89D3400362A0F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6452955118D89D3400362A0F /* QuartzCore.framework */; };
 		64582DAE164165C200CF5DB9 /* OTMAboutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 64582DAD164165C200CF5DB9 /* OTMAboutViewController.m */; };
-		645AA4B718F872FA00C00EC1 /* location_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 645AA4B518F872FA00C00EC1 /* location_marker.png */; };
-		645AA4B818F872FA00C00EC1 /* location_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 645AA4B618F872FA00C00EC1 /* location_marker@2x.png */; };
 		64608648160CFB0A00A1458B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 64608646160CFB0A00A1458B /* InfoPlist.strings */; };
 		6460864B160CFB2800A1458B /* OpenTreeMap-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 64608649160CFB2800A1458B /* OpenTreeMap-Info.plist */; };
 		6460864C160CFB2800A1458B /* OpenTreeMap.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 6460864A160CFB2800A1458B /* OpenTreeMap.entitlements */; };
@@ -84,40 +82,6 @@
 		646087C3160D01A700A1458B /* Implementation.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6460877B160D01A700A1458B /* Implementation.plist */; };
 		646087CC160D01D900A1458B /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C5160D01D900A1458B /* Default.png */; };
 		646087CD160D01D900A1458B /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 646087C6160D01D900A1458B /* Default@2x.png */; };
-		6470BEB418DB7FF800C56A8F /* Chevron_left.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9218DB7FF800C56A8F /* Chevron_left.png */; };
-		6470BEB518DB7FF800C56A8F /* Chevron_left@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */; };
-		6470BEB618DB7FF800C56A8F /* Chevron_right.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9418DB7FF800C56A8F /* Chevron_right.png */; };
-		6470BEB718DB7FF800C56A8F /* Chevron_right@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */; };
-		6470BEB818DB7FF800C56A8F /* Default_feature-image.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9618DB7FF800C56A8F /* Default_feature-image.png */; };
-		6470BEB918DB7FF800C56A8F /* Default_feature-image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */; };
-		6470BEBA18DB7FF800C56A8F /* handle_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9818DB7FF800C56A8F /* handle_icon.png */; };
-		6470BEBB18DB7FF800C56A8F /* handle_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */; };
-		6470BEBC18DB7FF800C56A8F /* Profile_favorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */; };
-		6470BEBD18DB7FF800C56A8F /* Profile_favorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */; };
-		6470BEBE18DB7FF800C56A8F /* Profile_unfavorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */; };
-		6470BEBF18DB7FF800C56A8F /* Profile_unfavorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */; };
-		6470BEC018DB7FF800C56A8F /* selected_marker_small.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */; };
-		6470BEC118DB7FF800C56A8F /* selected_marker_small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */; };
-		6470BEC218DB7FF800C56A8F /* selected_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA018DB7FF800C56A8F /* selected_marker.png */; };
-		6470BEC318DB7FF800C56A8F /* selected_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */; };
-		6470BEC418DB7FF800C56A8F /* TabBar_about-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */; };
-		6470BEC518DB7FF800C56A8F /* TabBar_about-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */; };
-		6470BEC618DB7FF800C56A8F /* TabBar_about.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA418DB7FF800C56A8F /* TabBar_about.png */; };
-		6470BEC718DB7FF800C56A8F /* TabBar_about@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */; };
-		6470BEC818DB7FF800C56A8F /* TabBar_details-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */; };
-		6470BEC918DB7FF800C56A8F /* TabBar_details-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */; };
-		6470BECA18DB7FF800C56A8F /* TabBar_details.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA818DB7FF800C56A8F /* TabBar_details.png */; };
-		6470BECB18DB7FF800C56A8F /* TabBar_details@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */; };
-		6470BECC18DB7FF800C56A8F /* TabBar_profile-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */; };
-		6470BECD18DB7FF800C56A8F /* TabBar_profile-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */; };
-		6470BECE18DB7FF800C56A8F /* TabBar_profile.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */; };
-		6470BECF18DB7FF800C56A8F /* TabBar_profile@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */; };
-		6470BED018DB7FF800C56A8F /* TabBar_treemap-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */; };
-		6470BED118DB7FF800C56A8F /* TabBar_treemap-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */; };
-		6470BED218DB7FF800C56A8F /* TabBar_treemap.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */; };
-		6470BED318DB7FF800C56A8F /* TabBar_treemap@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */; };
-		6470BED418DB7FF800C56A8F /* Treemap_Contactbook.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */; };
-		6470BED518DB7FF800C56A8F /* Treemap_Contactbook@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */; };
 		6470BEE418DB8C0B00C56A8F /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE018DB8C0B00C56A8F /* Icon-72.png */; };
 		6470BEE518DB8C0B00C56A8F /* Icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE118DB8C0B00C56A8F /* Icon-72@2x.png */; };
 		6470BEE618DB8C0B00C56A8F /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6470BEE218DB8C0B00C56A8F /* Icon.png */; };
@@ -129,12 +93,48 @@
 		649426E719008F3300923470 /* SettingsIcon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 649426E319008F3300923470 /* SettingsIcon@2x.png */; };
 		649426E819008F3300923470 /* SpotlightIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 649426E419008F3300923470 /* SpotlightIcon.png */; };
 		649426E919008F3300923470 /* SpotlightIcon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 649426E519008F3300923470 /* SpotlightIcon@2x.png */; };
-		649BEFE018E466A90031A606 /* gps_icon_14.png in Resources */ = {isa = PBXBuildFile; fileRef = 649BEFDC18E466A90031A606 /* gps_icon_14.png */; };
-		649BEFE118E466A90031A606 /* gps_icon_14@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 649BEFDD18E466A90031A606 /* gps_icon_14@2x.png */; };
-		649BEFE218E466A90031A606 /* gps_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 649BEFDE18E466A90031A606 /* gps_icon.png */; };
-		649BEFE318E466A90031A606 /* gps_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 649BEFDF18E466A90031A606 /* gps_icon@2x.png */; };
 		649F92D5190AB7BC0098D3BB /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 649F92D4190AB7BC0098D3BB /* MessageUI.framework */; };
 		649F92D8190AF5B40098D3BB /* OTMInappropriateContentMailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 649F92D7190AF5B40098D3BB /* OTMInappropriateContentMailViewController.m */; };
+		64D458F5190EF3BA005BAF47 /* Chevron_left.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458CC190EF3BA005BAF47 /* Chevron_left.png */; };
+		64D458F6190EF3BA005BAF47 /* Chevron_left@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458CD190EF3BA005BAF47 /* Chevron_left@2x.png */; };
+		64D458F7190EF3BA005BAF47 /* Chevron_right.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458CE190EF3BA005BAF47 /* Chevron_right.png */; };
+		64D458F8190EF3BA005BAF47 /* Chevron_right@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458CF190EF3BA005BAF47 /* Chevron_right@2x.png */; };
+		64D458F9190EF3BA005BAF47 /* Default_feature-image.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D0190EF3BA005BAF47 /* Default_feature-image.png */; };
+		64D458FA190EF3BA005BAF47 /* Default_feature-image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D1190EF3BA005BAF47 /* Default_feature-image@2x.png */; };
+		64D458FB190EF3BA005BAF47 /* gps_icon_14.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D2190EF3BA005BAF47 /* gps_icon_14.png */; };
+		64D458FC190EF3BA005BAF47 /* gps_icon_14@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D3190EF3BA005BAF47 /* gps_icon_14@2x.png */; };
+		64D458FD190EF3BA005BAF47 /* gps_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D4190EF3BA005BAF47 /* gps_icon.png */; };
+		64D458FE190EF3BA005BAF47 /* gps_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D5190EF3BA005BAF47 /* gps_icon@2x.png */; };
+		64D458FF190EF3BA005BAF47 /* handle_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D6190EF3BA005BAF47 /* handle_icon.png */; };
+		64D45900190EF3BA005BAF47 /* handle_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D7190EF3BA005BAF47 /* handle_icon@2x.png */; };
+		64D45902190EF3BA005BAF47 /* location_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458D9190EF3BA005BAF47 /* location_marker.png */; };
+		64D45903190EF3BA005BAF47 /* location_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DA190EF3BA005BAF47 /* location_marker@2x.png */; };
+		64D45904190EF3BA005BAF47 /* Profile_favorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DB190EF3BA005BAF47 /* Profile_favorited.png */; };
+		64D45905190EF3BA005BAF47 /* Profile_favorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DC190EF3BA005BAF47 /* Profile_favorited@2x.png */; };
+		64D45906190EF3BA005BAF47 /* Profile_unfavorited.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DD190EF3BA005BAF47 /* Profile_unfavorited.png */; };
+		64D45907190EF3BA005BAF47 /* Profile_unfavorited@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DE190EF3BA005BAF47 /* Profile_unfavorited@2x.png */; };
+		64D45908190EF3BA005BAF47 /* selected_marker_small.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458DF190EF3BA005BAF47 /* selected_marker_small.png */; };
+		64D45909190EF3BA005BAF47 /* selected_marker_small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E0190EF3BA005BAF47 /* selected_marker_small@2x.png */; };
+		64D4590A190EF3BA005BAF47 /* selected_marker.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E1190EF3BA005BAF47 /* selected_marker.png */; };
+		64D4590B190EF3BA005BAF47 /* selected_marker@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E2190EF3BA005BAF47 /* selected_marker@2x.png */; };
+		64D4590C190EF3BA005BAF47 /* TabBar_about-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E3190EF3BA005BAF47 /* TabBar_about-active.png */; };
+		64D4590D190EF3BA005BAF47 /* TabBar_about-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E4190EF3BA005BAF47 /* TabBar_about-active@2x.png */; };
+		64D4590E190EF3BA005BAF47 /* TabBar_about.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E5190EF3BA005BAF47 /* TabBar_about.png */; };
+		64D4590F190EF3BA005BAF47 /* TabBar_about@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E6190EF3BA005BAF47 /* TabBar_about@2x.png */; };
+		64D45910190EF3BA005BAF47 /* TabBar_details-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E7190EF3BA005BAF47 /* TabBar_details-active.png */; };
+		64D45911190EF3BA005BAF47 /* TabBar_details-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E8190EF3BA005BAF47 /* TabBar_details-active@2x.png */; };
+		64D45912190EF3BA005BAF47 /* TabBar_details.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458E9190EF3BA005BAF47 /* TabBar_details.png */; };
+		64D45913190EF3BA005BAF47 /* TabBar_details@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458EA190EF3BA005BAF47 /* TabBar_details@2x.png */; };
+		64D45914190EF3BA005BAF47 /* TabBar_profile-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458EB190EF3BA005BAF47 /* TabBar_profile-active.png */; };
+		64D45915190EF3BA005BAF47 /* TabBar_profile-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458EC190EF3BA005BAF47 /* TabBar_profile-active@2x.png */; };
+		64D45916190EF3BA005BAF47 /* TabBar_profile.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458ED190EF3BA005BAF47 /* TabBar_profile.png */; };
+		64D45917190EF3BA005BAF47 /* TabBar_profile@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458EE190EF3BA005BAF47 /* TabBar_profile@2x.png */; };
+		64D45918190EF3BA005BAF47 /* TabBar_treemap-active.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458EF190EF3BA005BAF47 /* TabBar_treemap-active.png */; };
+		64D45919190EF3BA005BAF47 /* TabBar_treemap-active@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458F0190EF3BA005BAF47 /* TabBar_treemap-active@2x.png */; };
+		64D4591A190EF3BA005BAF47 /* TabBar_treemap.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458F1190EF3BA005BAF47 /* TabBar_treemap.png */; };
+		64D4591B190EF3BA005BAF47 /* TabBar_treemap@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458F2190EF3BA005BAF47 /* TabBar_treemap@2x.png */; };
+		64D4591C190EF3BA005BAF47 /* Treemap_Contactbook.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458F3190EF3BA005BAF47 /* Treemap_Contactbook.png */; };
+		64D4591D190EF3BA005BAF47 /* Treemap_Contactbook@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64D458F4190EF3BA005BAF47 /* Treemap_Contactbook@2x.png */; };
 		64DDCDB514F51ADF004FA0CF /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64DDCDB414F51ADF004FA0CF /* CoreLocation.framework */; };
 		64DDCDB714F51AF6004FA0CF /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64DDCDB614F51AF6004FA0CF /* MapKit.framework */; };
 		64E5CCD418E0C2B6007E8173 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 64E5CCD318E0C2B6007E8173 /* Default-568h@2x.png */; };
@@ -172,8 +172,6 @@
 		6452955118D89D3400362A0F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		64582DAC164165C200CF5DB9 /* OTMAboutViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMAboutViewController.h; sourceTree = "<group>"; };
 		64582DAD164165C200CF5DB9 /* OTMAboutViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMAboutViewController.m; sourceTree = "<group>"; };
-		645AA4B518F872FA00C00EC1 /* location_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = location_marker.png; path = "../../../../otm-mobile-skins/la/ios/images/location_marker.png"; sourceTree = "<group>"; };
-		645AA4B618F872FA00C00EC1 /* location_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "location_marker@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/location_marker@2x.png"; sourceTree = "<group>"; };
 		64608647160CFB0A00A1458B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		64608649160CFB2800A1458B /* OpenTreeMap-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "OpenTreeMap-Info.plist"; sourceTree = "<group>"; };
 		6460864A160CFB2800A1458B /* OpenTreeMap.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = OpenTreeMap.entitlements; sourceTree = "<group>"; };
@@ -307,40 +305,6 @@
 		6460877B160D01A700A1458B /* Implementation.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Implementation.plist; sourceTree = "<group>"; };
 		646087C5160D01D900A1458B /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		646087C6160D01D900A1458B /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
-		6470BE9218DB7FF800C56A8F /* Chevron_left.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Chevron_left.png; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_left.png"; sourceTree = "<group>"; };
-		6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Chevron_left@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_left@2x.png"; sourceTree = "<group>"; };
-		6470BE9418DB7FF800C56A8F /* Chevron_right.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Chevron_right.png; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_right.png"; sourceTree = "<group>"; };
-		6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Chevron_right@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Chevron_right@2x.png"; sourceTree = "<group>"; };
-		6470BE9618DB7FF800C56A8F /* Default_feature-image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default_feature-image.png"; path = "../../../../otm-mobile-skins/la/ios/images/Default_feature-image.png"; sourceTree = "<group>"; };
-		6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default_feature-image@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Default_feature-image@2x.png"; sourceTree = "<group>"; };
-		6470BE9818DB7FF800C56A8F /* handle_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = handle_icon.png; path = "../../../../otm-mobile-skins/la/ios/images/handle_icon.png"; sourceTree = "<group>"; };
-		6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "handle_icon@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/handle_icon@2x.png"; sourceTree = "<group>"; };
-		6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Profile_favorited.png; path = "../../../../otm-mobile-skins/la/ios/images/Profile_favorited.png"; sourceTree = "<group>"; };
-		6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Profile_favorited@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Profile_favorited@2x.png"; sourceTree = "<group>"; };
-		6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Profile_unfavorited.png; path = "../../../../otm-mobile-skins/la/ios/images/Profile_unfavorited.png"; sourceTree = "<group>"; };
-		6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Profile_unfavorited@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Profile_unfavorited@2x.png"; sourceTree = "<group>"; };
-		6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = selected_marker_small.png; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker_small.png"; sourceTree = "<group>"; };
-		6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "selected_marker_small@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker_small@2x.png"; sourceTree = "<group>"; };
-		6470BEA018DB7FF800C56A8F /* selected_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = selected_marker.png; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker.png"; sourceTree = "<group>"; };
-		6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "selected_marker@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/selected_marker@2x.png"; sourceTree = "<group>"; };
-		6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about-active.png"; sourceTree = "<group>"; };
-		6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about-active@2x.png"; sourceTree = "<group>"; };
-		6470BEA418DB7FF800C56A8F /* TabBar_about.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_about.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about.png"; sourceTree = "<group>"; };
-		6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_about@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_about@2x.png"; sourceTree = "<group>"; };
-		6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details-active.png"; sourceTree = "<group>"; };
-		6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details-active@2x.png"; sourceTree = "<group>"; };
-		6470BEA818DB7FF800C56A8F /* TabBar_details.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_details.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details.png"; sourceTree = "<group>"; };
-		6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_details@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_details@2x.png"; sourceTree = "<group>"; };
-		6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile-active.png"; sourceTree = "<group>"; };
-		6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile-active@2x.png"; sourceTree = "<group>"; };
-		6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_profile.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile.png"; sourceTree = "<group>"; };
-		6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_profile@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_profile@2x.png"; sourceTree = "<group>"; };
-		6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap-active.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap-active.png"; sourceTree = "<group>"; };
-		6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap-active@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap-active@2x.png"; sourceTree = "<group>"; };
-		6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = TabBar_treemap.png; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap.png"; sourceTree = "<group>"; };
-		6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "TabBar_treemap@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/TabBar_treemap@2x.png"; sourceTree = "<group>"; };
-		6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Treemap_Contactbook.png; path = "../../../../otm-mobile-skins/la/ios/images/Treemap_Contactbook.png"; sourceTree = "<group>"; };
-		6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Treemap_Contactbook@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/Treemap_Contactbook@2x.png"; sourceTree = "<group>"; };
 		6470BEE018DB8C0B00C56A8F /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72.png"; sourceTree = "<group>"; };
 		6470BEE118DB8C0B00C56A8F /* Icon-72@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72@2x.png"; sourceTree = "<group>"; };
 		6470BEE218DB8C0B00C56A8F /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
@@ -354,13 +318,49 @@
 		649426E319008F3300923470 /* SettingsIcon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "SettingsIcon@2x.png"; sourceTree = "<group>"; };
 		649426E419008F3300923470 /* SpotlightIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SpotlightIcon.png; sourceTree = "<group>"; };
 		649426E519008F3300923470 /* SpotlightIcon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "SpotlightIcon@2x.png"; sourceTree = "<group>"; };
-		649BEFDC18E466A90031A606 /* gps_icon_14.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = gps_icon_14.png; path = "../../../../otm-mobile-skins/la/ios/images/gps_icon_14.png"; sourceTree = "<group>"; };
-		649BEFDD18E466A90031A606 /* gps_icon_14@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "gps_icon_14@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/gps_icon_14@2x.png"; sourceTree = "<group>"; };
-		649BEFDE18E466A90031A606 /* gps_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = gps_icon.png; path = "../../../../otm-mobile-skins/la/ios/images/gps_icon.png"; sourceTree = "<group>"; };
-		649BEFDF18E466A90031A606 /* gps_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "gps_icon@2x.png"; path = "../../../../otm-mobile-skins/la/ios/images/gps_icon@2x.png"; sourceTree = "<group>"; };
 		649F92D4190AB7BC0098D3BB /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		649F92D6190AF5B40098D3BB /* OTMInappropriateContentMailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTMInappropriateContentMailViewController.h; sourceTree = "<group>"; };
 		649F92D7190AF5B40098D3BB /* OTMInappropriateContentMailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTMInappropriateContentMailViewController.m; sourceTree = "<group>"; };
+		64D458CC190EF3BA005BAF47 /* Chevron_left.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Chevron_left.png; sourceTree = "<group>"; };
+		64D458CD190EF3BA005BAF47 /* Chevron_left@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Chevron_left@2x.png"; sourceTree = "<group>"; };
+		64D458CE190EF3BA005BAF47 /* Chevron_right.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Chevron_right.png; sourceTree = "<group>"; };
+		64D458CF190EF3BA005BAF47 /* Chevron_right@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Chevron_right@2x.png"; sourceTree = "<group>"; };
+		64D458D0190EF3BA005BAF47 /* Default_feature-image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default_feature-image.png"; sourceTree = "<group>"; };
+		64D458D1190EF3BA005BAF47 /* Default_feature-image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default_feature-image@2x.png"; sourceTree = "<group>"; };
+		64D458D2190EF3BA005BAF47 /* gps_icon_14.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gps_icon_14.png; sourceTree = "<group>"; };
+		64D458D3190EF3BA005BAF47 /* gps_icon_14@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gps_icon_14@2x.png"; sourceTree = "<group>"; };
+		64D458D4190EF3BA005BAF47 /* gps_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gps_icon.png; sourceTree = "<group>"; };
+		64D458D5190EF3BA005BAF47 /* gps_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gps_icon@2x.png"; sourceTree = "<group>"; };
+		64D458D6190EF3BA005BAF47 /* handle_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = handle_icon.png; sourceTree = "<group>"; };
+		64D458D7190EF3BA005BAF47 /* handle_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "handle_icon@2x.png"; sourceTree = "<group>"; };
+		64D458D9190EF3BA005BAF47 /* location_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = location_marker.png; sourceTree = "<group>"; };
+		64D458DA190EF3BA005BAF47 /* location_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "location_marker@2x.png"; sourceTree = "<group>"; };
+		64D458DB190EF3BA005BAF47 /* Profile_favorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Profile_favorited.png; sourceTree = "<group>"; };
+		64D458DC190EF3BA005BAF47 /* Profile_favorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Profile_favorited@2x.png"; sourceTree = "<group>"; };
+		64D458DD190EF3BA005BAF47 /* Profile_unfavorited.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Profile_unfavorited.png; sourceTree = "<group>"; };
+		64D458DE190EF3BA005BAF47 /* Profile_unfavorited@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Profile_unfavorited@2x.png"; sourceTree = "<group>"; };
+		64D458DF190EF3BA005BAF47 /* selected_marker_small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = selected_marker_small.png; sourceTree = "<group>"; };
+		64D458E0190EF3BA005BAF47 /* selected_marker_small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "selected_marker_small@2x.png"; sourceTree = "<group>"; };
+		64D458E1190EF3BA005BAF47 /* selected_marker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = selected_marker.png; sourceTree = "<group>"; };
+		64D458E2190EF3BA005BAF47 /* selected_marker@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "selected_marker@2x.png"; sourceTree = "<group>"; };
+		64D458E3190EF3BA005BAF47 /* TabBar_about-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_about-active.png"; sourceTree = "<group>"; };
+		64D458E4190EF3BA005BAF47 /* TabBar_about-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_about-active@2x.png"; sourceTree = "<group>"; };
+		64D458E5190EF3BA005BAF47 /* TabBar_about.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBar_about.png; sourceTree = "<group>"; };
+		64D458E6190EF3BA005BAF47 /* TabBar_about@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_about@2x.png"; sourceTree = "<group>"; };
+		64D458E7190EF3BA005BAF47 /* TabBar_details-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_details-active.png"; sourceTree = "<group>"; };
+		64D458E8190EF3BA005BAF47 /* TabBar_details-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_details-active@2x.png"; sourceTree = "<group>"; };
+		64D458E9190EF3BA005BAF47 /* TabBar_details.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBar_details.png; sourceTree = "<group>"; };
+		64D458EA190EF3BA005BAF47 /* TabBar_details@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_details@2x.png"; sourceTree = "<group>"; };
+		64D458EB190EF3BA005BAF47 /* TabBar_profile-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_profile-active.png"; sourceTree = "<group>"; };
+		64D458EC190EF3BA005BAF47 /* TabBar_profile-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_profile-active@2x.png"; sourceTree = "<group>"; };
+		64D458ED190EF3BA005BAF47 /* TabBar_profile.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBar_profile.png; sourceTree = "<group>"; };
+		64D458EE190EF3BA005BAF47 /* TabBar_profile@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_profile@2x.png"; sourceTree = "<group>"; };
+		64D458EF190EF3BA005BAF47 /* TabBar_treemap-active.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_treemap-active.png"; sourceTree = "<group>"; };
+		64D458F0190EF3BA005BAF47 /* TabBar_treemap-active@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_treemap-active@2x.png"; sourceTree = "<group>"; };
+		64D458F1190EF3BA005BAF47 /* TabBar_treemap.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBar_treemap.png; sourceTree = "<group>"; };
+		64D458F2190EF3BA005BAF47 /* TabBar_treemap@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TabBar_treemap@2x.png"; sourceTree = "<group>"; };
+		64D458F3190EF3BA005BAF47 /* Treemap_Contactbook.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Treemap_Contactbook.png; sourceTree = "<group>"; };
+		64D458F4190EF3BA005BAF47 /* Treemap_Contactbook@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Treemap_Contactbook@2x.png"; sourceTree = "<group>"; };
 		64DDCDB414F51ADF004FA0CF /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		64DDCDB614F51AF6004FA0CF /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		64E5CCD318E0C2B6007E8173 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
@@ -676,46 +676,46 @@
 		64608738160D01A700A1458B /* images */ = {
 			isa = PBXGroup;
 			children = (
-				649BEFDC18E466A90031A606 /* gps_icon_14.png */,
-				649BEFDD18E466A90031A606 /* gps_icon_14@2x.png */,
-				649BEFDE18E466A90031A606 /* gps_icon.png */,
-				649BEFDF18E466A90031A606 /* gps_icon@2x.png */,
-				6470BE9218DB7FF800C56A8F /* Chevron_left.png */,
-				6470BE9318DB7FF800C56A8F /* Chevron_left@2x.png */,
-				6470BE9418DB7FF800C56A8F /* Chevron_right.png */,
-				6470BE9518DB7FF800C56A8F /* Chevron_right@2x.png */,
-				6470BE9618DB7FF800C56A8F /* Default_feature-image.png */,
-				6470BE9718DB7FF800C56A8F /* Default_feature-image@2x.png */,
-				6470BE9818DB7FF800C56A8F /* handle_icon.png */,
-				6470BE9918DB7FF800C56A8F /* handle_icon@2x.png */,
-				645AA4B518F872FA00C00EC1 /* location_marker.png */,
-				645AA4B618F872FA00C00EC1 /* location_marker@2x.png */,
-				6470BE9A18DB7FF800C56A8F /* Profile_favorited.png */,
-				6470BE9B18DB7FF800C56A8F /* Profile_favorited@2x.png */,
-				6470BE9C18DB7FF800C56A8F /* Profile_unfavorited.png */,
-				6470BE9D18DB7FF800C56A8F /* Profile_unfavorited@2x.png */,
-				6470BE9E18DB7FF800C56A8F /* selected_marker_small.png */,
-				6470BE9F18DB7FF800C56A8F /* selected_marker_small@2x.png */,
-				6470BEA018DB7FF800C56A8F /* selected_marker.png */,
-				6470BEA118DB7FF800C56A8F /* selected_marker@2x.png */,
-				6470BEA218DB7FF800C56A8F /* TabBar_about-active.png */,
-				6470BEA318DB7FF800C56A8F /* TabBar_about-active@2x.png */,
-				6470BEA418DB7FF800C56A8F /* TabBar_about.png */,
-				6470BEA518DB7FF800C56A8F /* TabBar_about@2x.png */,
-				6470BEA618DB7FF800C56A8F /* TabBar_details-active.png */,
-				6470BEA718DB7FF800C56A8F /* TabBar_details-active@2x.png */,
-				6470BEA818DB7FF800C56A8F /* TabBar_details.png */,
-				6470BEA918DB7FF800C56A8F /* TabBar_details@2x.png */,
-				6470BEAA18DB7FF800C56A8F /* TabBar_profile-active.png */,
-				6470BEAB18DB7FF800C56A8F /* TabBar_profile-active@2x.png */,
-				6470BEAC18DB7FF800C56A8F /* TabBar_profile.png */,
-				6470BEAD18DB7FF800C56A8F /* TabBar_profile@2x.png */,
-				6470BEAE18DB7FF800C56A8F /* TabBar_treemap-active.png */,
-				6470BEAF18DB7FF800C56A8F /* TabBar_treemap-active@2x.png */,
-				6470BEB018DB7FF800C56A8F /* TabBar_treemap.png */,
-				6470BEB118DB7FF800C56A8F /* TabBar_treemap@2x.png */,
-				6470BEB218DB7FF800C56A8F /* Treemap_Contactbook.png */,
-				6470BEB318DB7FF800C56A8F /* Treemap_Contactbook@2x.png */,
+				64D458CC190EF3BA005BAF47 /* Chevron_left.png */,
+				64D458CD190EF3BA005BAF47 /* Chevron_left@2x.png */,
+				64D458CE190EF3BA005BAF47 /* Chevron_right.png */,
+				64D458CF190EF3BA005BAF47 /* Chevron_right@2x.png */,
+				64D458D0190EF3BA005BAF47 /* Default_feature-image.png */,
+				64D458D1190EF3BA005BAF47 /* Default_feature-image@2x.png */,
+				64D458D2190EF3BA005BAF47 /* gps_icon_14.png */,
+				64D458D3190EF3BA005BAF47 /* gps_icon_14@2x.png */,
+				64D458D4190EF3BA005BAF47 /* gps_icon.png */,
+				64D458D5190EF3BA005BAF47 /* gps_icon@2x.png */,
+				64D458D6190EF3BA005BAF47 /* handle_icon.png */,
+				64D458D7190EF3BA005BAF47 /* handle_icon@2x.png */,
+				64D458D9190EF3BA005BAF47 /* location_marker.png */,
+				64D458DA190EF3BA005BAF47 /* location_marker@2x.png */,
+				64D458DB190EF3BA005BAF47 /* Profile_favorited.png */,
+				64D458DC190EF3BA005BAF47 /* Profile_favorited@2x.png */,
+				64D458DD190EF3BA005BAF47 /* Profile_unfavorited.png */,
+				64D458DE190EF3BA005BAF47 /* Profile_unfavorited@2x.png */,
+				64D458DF190EF3BA005BAF47 /* selected_marker_small.png */,
+				64D458E0190EF3BA005BAF47 /* selected_marker_small@2x.png */,
+				64D458E1190EF3BA005BAF47 /* selected_marker.png */,
+				64D458E2190EF3BA005BAF47 /* selected_marker@2x.png */,
+				64D458E3190EF3BA005BAF47 /* TabBar_about-active.png */,
+				64D458E4190EF3BA005BAF47 /* TabBar_about-active@2x.png */,
+				64D458E5190EF3BA005BAF47 /* TabBar_about.png */,
+				64D458E6190EF3BA005BAF47 /* TabBar_about@2x.png */,
+				64D458E7190EF3BA005BAF47 /* TabBar_details-active.png */,
+				64D458E8190EF3BA005BAF47 /* TabBar_details-active@2x.png */,
+				64D458E9190EF3BA005BAF47 /* TabBar_details.png */,
+				64D458EA190EF3BA005BAF47 /* TabBar_details@2x.png */,
+				64D458EB190EF3BA005BAF47 /* TabBar_profile-active.png */,
+				64D458EC190EF3BA005BAF47 /* TabBar_profile-active@2x.png */,
+				64D458ED190EF3BA005BAF47 /* TabBar_profile.png */,
+				64D458EE190EF3BA005BAF47 /* TabBar_profile@2x.png */,
+				64D458EF190EF3BA005BAF47 /* TabBar_treemap-active.png */,
+				64D458F0190EF3BA005BAF47 /* TabBar_treemap-active@2x.png */,
+				64D458F1190EF3BA005BAF47 /* TabBar_treemap.png */,
+				64D458F2190EF3BA005BAF47 /* TabBar_treemap@2x.png */,
+				64D458F3190EF3BA005BAF47 /* Treemap_Contactbook.png */,
+				64D458F4190EF3BA005BAF47 /* Treemap_Contactbook@2x.png */,
 			);
 			path = images;
 			sourceTree = "<group>";
@@ -846,67 +846,67 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				64D458FA190EF3BA005BAF47 /* Default_feature-image@2x.png in Resources */,
 				649426E919008F3300923470 /* SpotlightIcon@2x.png in Resources */,
-				645AA4B818F872FA00C00EC1 /* location_marker@2x.png in Resources */,
+				64D458F8190EF3BA005BAF47 /* Chevron_right@2x.png in Resources */,
+				64D4591D190EF3BA005BAF47 /* Treemap_Contactbook@2x.png in Resources */,
 				6470BEE618DB8C0B00C56A8F /* Icon.png in Resources */,
+				64D45906190EF3BA005BAF47 /* Profile_unfavorited.png in Resources */,
+				64D45900190EF3BA005BAF47 /* handle_icon@2x.png in Resources */,
 				64608648160CFB0A00A1458B /* InfoPlist.strings in Resources */,
+				64D45905190EF3BA005BAF47 /* Profile_favorited@2x.png in Resources */,
+				64D45911190EF3BA005BAF47 /* TabBar_details-active@2x.png in Resources */,
 				6460864B160CFB2800A1458B /* OpenTreeMap-Info.plist in Resources */,
 				6460864C160CFB2800A1458B /* OpenTreeMap.entitlements in Resources */,
 				64608653160CFB4600A1458B /* LoginRequiredView.xib in Resources */,
+				64D45908190EF3BA005BAF47 /* selected_marker_small.png in Resources */,
+				64D458F5190EF3BA005BAF47 /* Chevron_left.png in Resources */,
+				64D458FD190EF3BA005BAF47 /* gps_icon.png in Resources */,
+				64D4590E190EF3BA005BAF47 /* TabBar_about.png in Resources */,
 				64608654160CFB4600A1458B /* LoginStoryboard.storyboard in Resources */,
 				64608655160CFB4600A1458B /* MainStoryboard_iPhone.storyboard in Resources */,
 				64608656160CFB4600A1458B /* OTMBenefitsTableViewCell.xib in Resources */,
-				649BEFE018E466A90031A606 /* gps_icon_14.png in Resources */,
-				649BEFE218E466A90031A606 /* gps_icon.png in Resources */,
+				64D458FB190EF3BA005BAF47 /* gps_icon_14.png in Resources */,
+				64D4591A190EF3BA005BAF47 /* TabBar_treemap.png in Resources */,
 				64E5CCD418E0C2B6007E8173 /* Default-568h@2x.png in Resources */,
 				64608657160CFB4600A1458B /* OTMDBHTableViewCell.xib in Resources */,
+				64D4590F190EF3BA005BAF47 /* TabBar_about@2x.png in Resources */,
 				6470BEE418DB8C0B00C56A8F /* Icon-72.png in Resources */,
+				64D458F9190EF3BA005BAF47 /* Default_feature-image.png in Resources */,
+				64D458FE190EF3BA005BAF47 /* gps_icon@2x.png in Resources */,
+				64D458FC190EF3BA005BAF47 /* gps_icon_14@2x.png in Resources */,
 				649426E719008F3300923470 /* SettingsIcon@2x.png in Resources */,
-				6470BECA18DB7FF800C56A8F /* TabBar_details.png in Resources */,
-				6470BED318DB7FF800C56A8F /* TabBar_treemap@2x.png in Resources */,
-				6470BED018DB7FF800C56A8F /* TabBar_treemap-active.png in Resources */,
-				645AA4B718F872FA00C00EC1 /* location_marker.png in Resources */,
-				6470BEC418DB7FF800C56A8F /* TabBar_about-active.png in Resources */,
-				6470BECC18DB7FF800C56A8F /* TabBar_profile-active.png in Resources */,
-				6470BEB518DB7FF800C56A8F /* Chevron_left@2x.png in Resources */,
+				64D458F7190EF3BA005BAF47 /* Chevron_right.png in Resources */,
+				64D458FF190EF3BA005BAF47 /* handle_icon.png in Resources */,
 				649426E619008F3300923470 /* SettingsIcon.png in Resources */,
-				6470BEBA18DB7FF800C56A8F /* handle_icon.png in Resources */,
-				6470BEC918DB7FF800C56A8F /* TabBar_details-active@2x.png in Resources */,
-				6470BEC318DB7FF800C56A8F /* selected_marker@2x.png in Resources */,
-				6470BEC618DB7FF800C56A8F /* TabBar_about.png in Resources */,
-				6470BEBD18DB7FF800C56A8F /* Profile_favorited@2x.png in Resources */,
-				6470BEB418DB7FF800C56A8F /* Chevron_left.png in Resources */,
-				6470BEB918DB7FF800C56A8F /* Default_feature-image@2x.png in Resources */,
-				6470BEC018DB7FF800C56A8F /* selected_marker_small.png in Resources */,
-				6470BED518DB7FF800C56A8F /* Treemap_Contactbook@2x.png in Resources */,
-				6470BEBB18DB7FF800C56A8F /* handle_icon@2x.png in Resources */,
-				6470BED118DB7FF800C56A8F /* TabBar_treemap-active@2x.png in Resources */,
-				6470BEBC18DB7FF800C56A8F /* Profile_favorited.png in Resources */,
-				6470BEC518DB7FF800C56A8F /* TabBar_about-active@2x.png in Resources */,
-				6470BED418DB7FF800C56A8F /* Treemap_Contactbook.png in Resources */,
-				6470BEC118DB7FF800C56A8F /* selected_marker_small@2x.png in Resources */,
-				6470BECF18DB7FF800C56A8F /* TabBar_profile@2x.png in Resources */,
-				6470BEB818DB7FF800C56A8F /* Default_feature-image.png in Resources */,
-				6470BEBF18DB7FF800C56A8F /* Profile_unfavorited@2x.png in Resources */,
-				6470BEB618DB7FF800C56A8F /* Chevron_right.png in Resources */,
-				649BEFE118E466A90031A606 /* gps_icon_14@2x.png in Resources */,
-				6470BECD18DB7FF800C56A8F /* TabBar_profile-active@2x.png in Resources */,
-				6470BECE18DB7FF800C56A8F /* TabBar_profile.png in Resources */,
-				6470BEC218DB7FF800C56A8F /* selected_marker.png in Resources */,
-				6470BECB18DB7FF800C56A8F /* TabBar_details@2x.png in Resources */,
-				6470BEC818DB7FF800C56A8F /* TabBar_details-active.png in Resources */,
-				649BEFE318E466A90031A606 /* gps_icon@2x.png in Resources */,
+				64D45915190EF3BA005BAF47 /* TabBar_profile-active@2x.png in Resources */,
 				646087C3160D01A700A1458B /* Implementation.plist in Resources */,
+				64D4591C190EF3BA005BAF47 /* Treemap_Contactbook.png in Resources */,
+				64D4590C190EF3BA005BAF47 /* TabBar_about-active.png in Resources */,
 				646087CC160D01D900A1458B /* Default.png in Resources */,
+				64D45907190EF3BA005BAF47 /* Profile_unfavorited@2x.png in Resources */,
+				64D45914190EF3BA005BAF47 /* TabBar_profile-active.png in Resources */,
+				64D4591B190EF3BA005BAF47 /* TabBar_treemap@2x.png in Resources */,
+				64D45917190EF3BA005BAF47 /* TabBar_profile@2x.png in Resources */,
 				646087CD160D01D900A1458B /* Default@2x.png in Resources */,
+				64D4590B190EF3BA005BAF47 /* selected_marker@2x.png in Resources */,
+				64D4590A190EF3BA005BAF47 /* selected_marker.png in Resources */,
+				64D45904190EF3BA005BAF47 /* Profile_favorited.png in Resources */,
 				647E445716417BDF000CF872 /* about.html in Resources */,
-				6470BEB718DB7FF800C56A8F /* Chevron_right@2x.png in Resources */,
+				64D45909190EF3BA005BAF47 /* selected_marker_small@2x.png in Resources */,
+				64D45902190EF3BA005BAF47 /* location_marker.png in Resources */,
+				64D45910190EF3BA005BAF47 /* TabBar_details-active.png in Resources */,
+				64D45919190EF3BA005BAF47 /* TabBar_treemap-active@2x.png in Resources */,
+				64D45912190EF3BA005BAF47 /* TabBar_details.png in Resources */,
 				6470BEE718DB8C0B00C56A8F /* Icon@2x.png in Resources */,
 				6470BEE518DB8C0B00C56A8F /* Icon-72@2x.png in Resources */,
-				6470BEC718DB7FF800C56A8F /* TabBar_about@2x.png in Resources */,
-				6470BED218DB7FF800C56A8F /* TabBar_treemap.png in Resources */,
-				6470BEBE18DB7FF800C56A8F /* Profile_unfavorited.png in Resources */,
+				64D45916190EF3BA005BAF47 /* TabBar_profile.png in Resources */,
+				64D45913190EF3BA005BAF47 /* TabBar_details@2x.png in Resources */,
+				64D45903190EF3BA005BAF47 /* location_marker@2x.png in Resources */,
 				649426E819008F3300923470 /* SpotlightIcon.png in Resources */,
+				64D45918190EF3BA005BAF47 /* TabBar_treemap-active.png in Resources */,
+				64D4590D190EF3BA005BAF47 /* TabBar_about-active@2x.png in Resources */,
+				64D458F6190EF3BA005BAF47 /* Chevron_left@2x.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
There was a sneaky problem in Jenkins where skin assets were being pulled from the wrong folder. The SD app was showing LA's default tree image. The root of the problem appears to be that the project file referenced a symlink path rather than a local path.

I removed the images folder from the project, copied one of the skin image folder into the local project path, and then added the images back into the project. In my local testing, I could now successfully replace the real directory with a symlink and the images would correctly change inside of Xcode.
