### PR TITLE
Disable autocorrect on username & password fields.

### DIFF
--- a/OpenTreeMap/resources/LoginStoryboard.storyboard
+++ b/OpenTreeMap/resources/LoginStoryboard.storyboard
@@ -36,7 +36,7 @@
                                         <rect key="frame" x="20" y="123" width="280" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress" returnKeyType="next"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                         <connections>
                                             <outlet property="delegate" destination="EnD-Jy-kmP" id="XKx-2o-kvH"/>
                                         </connections>
@@ -45,7 +45,7 @@
                                         <rect key="frame" x="20" y="162" width="280" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" returnKeyType="done" secureTextEntry="YES"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES"/>
                                         <connections>
                                             <outlet property="delegate" destination="EnD-Jy-kmP" id="IDn-4p-tz8"/>
                                         </connections>


### PR DESCRIPTION
I updated both username and password fields to skip autocorrection. I would
think that setting a field to "secure" would disable this by default but I was
unable to find an affirming statement in the docs so assumed it would be better
to play it safe and be specific.
