### PR TITLE
Check for duplicate email message.

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMRegistrationViewController.m
@@ -136,7 +136,18 @@
                                   cancelButtonTitle:@"OK"
                                   otherButtonTitles:nil] show];
                 [self.navigationController popToViewController:self animated:YES];
-            } else {
+            } else if (status == kOTMAPILoginDuplicateEmailAddress) {
+                [self.username becomeFirstResponder];
+                [self.username selectAll:self];
+                NSString *message = [NSString stringWithFormat:@"The email address %@ is already registered. Tap 'Login' with your existing user or choose a different email address.", self.email.text];
+                [[[UIAlertView alloc] initWithTitle:@"Already Registered"
+                                            message:message
+                                           delegate:nil
+                                  cancelButtonTitle:@"OK"
+                                  otherButtonTitles:nil] show];
+                [self.navigationController popToViewController:self animated:YES];
+            }
+            else {
                 [[[UIAlertView alloc] initWithTitle:@"Registration Failed"
                                            message:@"A server problem prevented your registration from completing. Please try again later."
                                           delegate:nil

--- a/OpenTreeMap/src/OTM/OTMAPI.h
+++ b/OpenTreeMap/src/OTM/OTMAPI.h
@@ -24,7 +24,8 @@ typedef enum {
     kOTMAPILoginResponseInvalidUsernameOrPassword,
     kOTMAPILoginResponseOK,
     kOTMAPILoginResponseError,
-    kOTMAPILoginDuplicateUsername
+    kOTMAPILoginDuplicateUsername,
+    kOTMAPILoginDuplicateEmailAddress
 } OTMAPILoginResponse;
 
 typedef void(^AZGenericCallback)(id obj, NSError* error);

--- a/OpenTreeMap/src/OTM/OTMAPI.m
+++ b/OpenTreeMap/src/OTM/OTMAPI.m
@@ -243,8 +243,13 @@
             if (error != nil) {
                 NSDictionary *info = [error userInfo];
                 NSNumber *statusCode = [info objectForKey:@"statusCode"];
+                NSString *message = [info objectForKey:@"body"];
                 if (statusCode && [statusCode intValue] == 409) {
-                    callback(user, nil, kOTMAPILoginDuplicateUsername);
+                    if ([message isEqualToString:@"Email is already in use"]) {
+                        callback(user, nil, kOTMAPILoginDuplicateEmailAddress);
+                    } else {
+                        callback(user, nil, kOTMAPILoginDuplicateUsername);
+                    }
                 } else {
                     callback(user, nil, kOTMAPILoginResponseError);
                 }


### PR DESCRIPTION
When creating a new user, the api server responds with a 409 when there is a
confilct for an email address or username. This was causing confution because
the app did not check which error was encountered and alerted the user that the
username was duplicated when sometimes it was the email address. In order to fix
this we check for the string returned by the api server in the message body and
use this to set a different error message. This is not wonderful since it relies
on the exact string from the API but I am adding a warning in the api server
code to let other devs know that changing that string might have bad
implications.
