### PR TITLE
Show rows when load more cell is not available.

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -375,6 +375,8 @@
 
             [cellsToReturn addObjectsFromArray:sortedCells];
             [cellsToReturn addObject:loadMore];
+        } else {
+            [cellsToReturn addObjectsFromArray:sortedCells];
         }
 
         NSDictionary *preparedCellsForSection =


### PR DESCRIPTION
We didn't have a case to show the stewardship and alert cells when the
more button was inactive (when there were fewer than four stewardships
or alerts in there respective sections. This change adds them.
