### PR TITLE
Add filter class for 'Default' type data.

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
@@ -38,7 +38,7 @@ typedef enum {
 - (BOOL)standardFiltersActive;
 - (BOOL)customFiltersActive;
 
-- (NSDictionary *)customFiltersDict;
+- (NSArray *)customFiltersData;
 
 - (NSString *)description;
 
@@ -74,6 +74,20 @@ typedef enum {
 
 - (id)initWithName:(NSString *)nm key:(NSString *)k;
 - (id)initWithName:(NSString *)nm key:(NSString *)k existanceFilter:(BOOL)existanceFilter;
+
+@end
+
+@interface OTMDefaultFilter : OTMFilter
+
+@property (nonatomic, readonly) UILabel *nameLbl;
+@property (nonatomic, readonly) UISwitch *toggle;
+@property (nonatomic, readonly) NSString *defaultKey;
+@property (nonatomic, readonly) NSString *defaultValue;
+
+- (id)initWithName:(NSString *)nm
+               key:(NSString *)k
+        defaultKey:(NSString *)dk
+      defaultValue:(NSString *)df;
 
 @end
 


### PR DESCRIPTION
We have creted a new type of field called a 'default' field. These are
fields that have a default value but are otherwise just a choice list.
This was developed to handle alerts which default to an unresolved
state. Since these are UDFs we need to pass in the id of the udf to the
tiler along with the data. Thus we look up the default value when
creating a new default filter and pass it in when creating the object.

Default type filters are also OR type filters for the tiler. This way a
user can search for plots and trees that have open alerts and get both
in the retured data set not just trees that have alerts and alerts for
their planting sites. In order to do this we had to restructure the data
passed in to the tiler query and create a sub-array that holds the OR
type filters.
