### PR TITLE
Adjust tiler query params.

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
@@ -80,12 +80,18 @@
     }
 
     NSMutableArray *queryData = [[NSMutableArray alloc] init];
-    [queryData addObject:@"AND"];
-    for (id key in andParams) {
-        [queryData addObject:@{key: [andParams objectForKey:key]}];
-    }
-    if ([orArray count]) {
-        [queryData addObject:orArray];
+    if ([andParams count]) {
+        [queryData addObject:@"AND"];
+        for (id key in andParams) {
+            [queryData addObject:@{key: [andParams objectForKey:key]}];
+        }
+        if ([orArray count]) {
+            [queryData addObject:orArray];
+        }
+    } else {
+        if ([orArray count]) {
+            queryData = orArray;
+        }
     }
 
     return queryData;


### PR DESCRIPTION
Our query to the tiler has become more complex with the addition of AND
as well as OR in the generated queries. We want to support things like:

```
WHERE edible = true
AND (tree_alerts = "unresolved" OR plot_alerts ="unresolved")
```

Because we build the params up from a structured array in the form:

```
['AND', {'edible':true}, ['OR', {'tree_alerts':'unresolved'},
{'plot_alerts:'unresolved'}]]
```

This creates problems if there are no conditions:

```
['AND']
```

Causing the tiler to return no results. To address this, we check to see
if there are AND conditions at all but the way we built up the array
caused issues if there were no leading conditions resulting in statement
such as:

```
[['OR', {'tree_alerts':'unresolved'}, {'plot_alerts:'unresolved'}]]
```

which is not considered a valid syntax by the tiler. As a result if
there are no leading conditions we return only the OR conditons as a
single array.

```
['OR', {'tree_alerts':'unresolved'}, {'plot_alerts:'unresolved'}]
```

Supplying only a single value in the OR params has not been found to
cause a problem (i.e. the following:

```
['OR', {'plot_alerts:'unresolved'}]
```

works just fine).
