### PR TITLE
Fix location services on iOS8.

### DIFF
--- a/OpenTreeMap/OpenTreeMap-Info.plist.template
+++ b/OpenTreeMap/OpenTreeMap-Info.plist.template
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	  <key>NSLocationWhenInUseUsageDescription</key>
+	  <string>OpenTreeMap uses your location to find trees near you.</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>

--- a/OpenTreeMap/src/OTM/Controllers/OTMNearbyTreesViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMNearbyTreesViewController.m
@@ -91,7 +91,14 @@
 
     [self updateList:segControl];
 
-    [self.locationManager startUpdatingLocation];
+    // Required to get iOS8 location services to run.
+     if ([self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) { // iOS8+
+        [self.locationManager requestWhenInUseAuthorization];
+        [self.locationManager startUpdatingLocation];
+    } else {
+        [self.locationManager startUpdatingLocation];
+    }
+
     [self reloadBackground];
 }
 

--- a/OpenTreeMap/src/OTM/OTMLocationManager.m
+++ b/OpenTreeMap/src/OTM/OTMLocationManager.m
@@ -53,7 +53,15 @@
         // The delegate is cleared in stopFindingLocation so it must be reset
         // here.
         [[self locationManager] setDelegate:self];
-        [[self locationManager] startUpdatingLocation];
+
+        // Required to get iOS8 location services to run.
+        if ([[self locationManager] respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+            [[self locationManager] requestWhenInUseAuthorization];
+            [[self locationManager] startUpdatingLocation];
+        } else {
+            [[self locationManager] startUpdatingLocation];
+        }
+
         NSTimeInterval timeout = [[[OTMEnvironment sharedEnvironment] locationSearchTimeoutInSeconds] doubleValue];
         [self performSelector:@selector(stopFindingLocationAndExecuteCallback) withObject:nil afterDelay:timeout];
     } else {


### PR DESCRIPTION
In order to use locations on iOS8 we must specify if we intend to use them at
all times or just while the user is actually active in the app. We must specify
a key in our info.plist "NSLocationWhenInUseUsageDescription" or all location
requests are ignored. Prior to calling startUpdatingLocation we must also call
to get the proper authorization. This is not available below iOS8 so we must
test for existence of the method before using it since we are going to target
both 7 and 8. Use of the key in the info plist will prevent the uncomfortable
warning that the app would like to use your location when at all times. Further
reference at:
https://developer.apple.com/library/prerelease/iOS/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/occ/instm/CLLocationManager/requestWhenInUseAuthorization
