### PR TITLE
Fix API requests from non-US locales.

### DIFF
--- a/OpenTreeMap/src/AZ/AZHttpRequest.m
+++ b/OpenTreeMap/src/AZ/AZHttpRequest.m
@@ -234,8 +234,10 @@
     url = [url stringByAppendingString:accessParam];
 
     NSTimeZone *timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    NSLocale *enLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
+    [formatter setLocale:enLocale];
     [formatter setTimeZone:timeZone];
 
     NSString *timestamp = [formatter stringFromDate:[NSDate date]];


### PR DESCRIPTION
I ran across this problem while testing other features. The device was
set to use UK English in non-24 hour time. As a result the date format
that was created and passed to the api was incorrect and caused the
application to fail when loading initial data. This did not happen when
the device was set to non-24 hour time with US English. Since users will
never see this string, we now hard code it to a known good format prior
to formatting it for the API.

Fixes https://github.com/OpenTreeMap/OpenTreeMap-iOS/issues/220
