### PR TITLE
Correct "Search All..." to "Search Public..."

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
@@ -283,7 +283,7 @@
         if (cell == nil) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:AllInstances];
         }
-        [cell.textLabel setText: @"Search All Tree Maps"];
+        [cell.textLabel setText: @"Search Public Tree Maps"];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         return cell;
     }


### PR DESCRIPTION
The button at the bottom of the initial instance select table view segues to a filterable list of public tree maps, not a list of "All" tree maps, as the previous button label suggested.

#### Before
<img width="320" alt="screen shot 2015-12-07 at 2 42 05 pm" src="https://cloud.githubusercontent.com/assets/17363/11640625/c58f1a30-9cf0-11e5-9092-e3e2ad634f95.png">

#### After
<img width="322" alt="screen shot 2015-12-07 at 2 40 54 pm" src="https://cloud.githubusercontent.com/assets/17363/11640592/940fe6c4-9cf0-11e5-9533-779766d5be1c.png">


Connects to #241