### PR TITLE
Serialize coordinates as double to keep precision

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -182,8 +182,8 @@
 {
     NSMutableDictionary *geometryDict = [[NSMutableDictionary alloc] init];
     [geometryDict setObject:@"4326" forKey:@"srid"];
-    [geometryDict setObject:[NSNumber numberWithFloat:annotation.coordinate.latitude] forKey:@"y"];
-    [geometryDict setObject:[NSNumber numberWithFloat:annotation.coordinate.longitude] forKey:@"x"];
+    [geometryDict setObject:[NSNumber numberWithDouble:annotation.coordinate.latitude] forKey:@"y"];
+    [geometryDict setObject:[NSNumber numberWithDouble:annotation.coordinate.longitude] forKey:@"x"];
     [geometryDict setObject:[NSNumber numberWithInt:4326] forKey:@"srid"];
 
     NSMutableDictionary *addTreeDict = [[NSMutableDictionary alloc] init];

--- a/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.m
+++ b/OpenTreeMap/src/OTM/OTMTreeDictionaryHelper.m
@@ -21,8 +21,8 @@
 {
     NSMutableDictionary *geometryDict = [[dict objectForKey:@"plot"] objectForKey:@"geom"];
 
-    [geometryDict setValue:[NSNumber numberWithFloat:coordinate.latitude] forKey:@"y"];
-    [geometryDict setValue:[NSNumber numberWithFloat:coordinate.longitude] forKey:@"x"];
+    [geometryDict setValue:[NSNumber numberWithDouble:coordinate.latitude] forKey:@"y"];
+    [geometryDict setValue:[NSNumber numberWithDouble:coordinate.longitude] forKey:@"x"];
 
     return dict;
 }


### PR DESCRIPTION
CLLocationCoordinate2D is a struct with latitude and longitude stored as doubles. When saving coordinates into a dictionary via NSNumber the conversion from double to float was causing a loss of numeric precision and, therefore, a loss of accuracy in setting the location of a plot.

The inaccuracy was most pronounced when coordinates have three digits to the left of the decimal point.

##### Before

```
{
    plot =     {
        "address_city" = Reno;
        "address_street" = "400\U2013498 E 6th St";
        "address_zip" = 89512;
        geom =         {
            srid = 4326;
            x = "-119.8077";
            y = "39.53378";
        };
    };
    tree =     {
    };
}
```

<img width="321" alt="screen shot 2015-12-15 at 10 27 51 am" src="https://cloud.githubusercontent.com/assets/17363/11818314/f35d0892-a316-11e5-86a6-8795a6bbfc5a.png">

##### After

```
{
    plot =     {
        "address_city" = Reno;
        "address_street" = "400\U2013498 E 6th St";
        "address_zip" = 89512;
        geom =         {
            srid = 4326;
            x = "-119.807749073744";
            y = "39.53377992317881";
        };
    };
    tree =     {
    };
}

```

<img width="322" alt="screen shot 2015-12-15 at 10 29 17 am" src="https://cloud.githubusercontent.com/assets/17363/11818355/2c8e0d8c-a317-11e5-8337-39eda1cd2190.png">

Connects to #233
