### PR TITLE
Improve instance loading workflow

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.h
@@ -21,6 +21,7 @@
 
 @property (nonatomic, strong) OTMLocationManager *locationManager;
 @property (nonatomic, strong) NSDictionary *instances;
+@property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
 
 @property (nonatomic, strong) IBOutlet UIButton *logInOutButton;
 

--- a/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
@@ -82,11 +82,8 @@
     if ([[[SharedAppDelegate loginManager] loggedInUser] loggedIn]) {
         [self.activityIndicatorView startAnimating];
         [[[OTMEnvironment sharedEnvironment] api]
-         getInstancesNearLatitude:0
-         longitude:0
-         user:[[SharedAppDelegate loginManager] loggedInUser]
-         maxResults:5
-         distance:0 callback:^(id json, NSError *error) {
+         getInstancesForUser:[[SharedAppDelegate loginManager] loggedInUser]
+                    callback:^(id json, NSError *error) {
              [self.activityIndicatorView stopAnimating];
              if (!error) {
                  if ([self oneOrMorePersonalInstancesInDictionary:json]) {

--- a/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMInstanceSelectTableViewController.m
@@ -42,6 +42,10 @@
     // Uncomment the following line to display an Edit button in the navigation
     // bar for this view controller.
     // self.navigationItem.rightBarButtonItem = self.editButtonItem;
+
+    self.activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    UIBarButtonItem *barButton = [[UIBarButtonItem alloc] initWithCustomView:self.activityIndicatorView];
+    self.navigationItem.rightBarButtonItem = barButton;
 }
 
 - (void)didReceiveMemoryWarning
@@ -70,39 +74,70 @@
         [self setLocationManager:[[OTMLocationManager alloc] initWithDistanceRestriction:NO]];
     }
 
-    // TODO: Maybe show loading indicator
-    [[self locationManager] findLocation:^(CLLocation *location, NSError *error) {
+    [self loadInstances];
+}
+
+- (void)loadInstances
+{
+    if ([[[SharedAppDelegate loginManager] loggedInUser] loggedIn]) {
+        [self.activityIndicatorView startAnimating];
+        [[[OTMEnvironment sharedEnvironment] api]
+         getInstancesNearLatitude:0
+         longitude:0
+         user:[[SharedAppDelegate loginManager] loggedInUser]
+         maxResults:5
+         distance:0 callback:^(id json, NSError *error) {
+             [self.activityIndicatorView stopAnimating];
+             if (!error) {
+                 if ([self oneOrMorePersonalInstancesInDictionary:json]) {
+                     [self updateInstancesFromDictionary:json];
+                 } else {
+                     [self loadNearbyInstances];
+                 }
+             } else {
+                 NSLog(@"Error getting instances for %@: %@", [[SharedAppDelegate loginManager] loggedInUser], error);
+                 [self loadNearbyInstances];
+             }
+         }];
+    } else {
+        [self loadNearbyInstances];
+    }
+}
+
+- (BOOL)oneOrMorePersonalInstancesInDictionary:(NSDictionary *)json
+{
+   if ([[json objectForKey:@"personal"] count])
+   {
+       return YES;
+   }
+   return NO;
+}
+
+- (void)loadNearbyInstances
+{
+    [self.activityIndicatorView startAnimating];
+    [[self locationManager] findLocationWithAccuracy:kCLLocationAccuracyThreeKilometers
+                                            callback:^(CLLocation *location, NSError *error) {
+        [self.activityIndicatorView stopAnimating];
         // TODO: if there is an error, we need to show some list of instances
         if (!error) {
+            [self.activityIndicatorView startAnimating];
             [[[OTMEnvironment sharedEnvironment] api]
              getInstancesNearLatitude:location.coordinate.latitude
-                            longitude:location.coordinate.longitude
-                                user:[[SharedAppDelegate loginManager] loggedInUser]
-                          maxResults:5
-                             distance:320000 callback:^(id json, NSError *error) {
-                                 if (!error) {
-                                     NSLog(@"Retrieved instances: %@", json);
-                                     [self updateInstancesFromDictionary:json];
-                                 } else {
-                                     NSLog(@"Error getting nearby instances: %@", error);
-                                 }
-            }];
+             longitude:location.coordinate.longitude
+             user:nil
+             maxResults:5
+             distance:320000 callback:^(id json, NSError *error) {
+                 [self.activityIndicatorView stopAnimating];
+                 if (!error) {
+                     NSLog(@"Retrieved instances: %@", json);
+                     [self updateInstancesFromDictionary:json];
+                 } else {
+                     NSLog(@"Error getting nearby instances: %@", error);
+                 }
+             }];
         } else {
             NSLog(@"Error finding location: %@", error);
-            if ([[[SharedAppDelegate loginManager] loggedInUser] loggedIn]) {
-                [[[OTMEnvironment sharedEnvironment] api]
-                 getInstancesNearLatitude:0
-                                longitude:0
-                                     user:[[SharedAppDelegate loginManager] loggedInUser]
-                               maxResults:5
-                                 distance:0 callback:^(id json, NSError *error) {
-                                     if (!error) {
-                                         [self updateInstancesFromDictionary:json];
-                                     } else {
-                                         NSLog(@"Error getting for: %@", error);
-                                     }
-                                 }];
-            }
         }
     }];
 }

--- a/OpenTreeMap/src/OTM/OTMAPI.h
+++ b/OpenTreeMap/src/OTM/OTMAPI.h
@@ -254,4 +254,10 @@ typedef void(^AZUserCallback)(OTMUser* user, NSDictionary *instance, OTMAPILogin
  */
 -(void)getInstancesNearLatitude:(double)lat longitude:(double)lon user:(OTMUser *)user maxResults:(NSUInteger)max distance:(double)distance callback:(AZJSONCallback)callback;
 
+/**
+ * Get the instances that a user is associated with. Calls
+ * getInstancesNearLatitude:longitude:user:maxResults:distance:callback: and passed a
+ * location in the middle of the ocean (0,0) to bypass finding nearby instances;
+ */
+-(void)getInstancesForUser:(OTMUser *)user callback:(AZJSONCallback)callback;
 @end

--- a/OpenTreeMap/src/OTM/OTMAPI.m
+++ b/OpenTreeMap/src/OTM/OTMAPI.m
@@ -170,6 +170,17 @@
                        [OTMAPI jsonCallback:callback]]];
 }
 
+-(void)getInstancesForUser:(OTMUser *)user callback:(AZJSONCallback)callback {
+    // The latest version of the API at the time this was written has a single API that gets both
+    // instances to which a user belongs and instances nearby. Passing a location of 0,0 (the middle
+    // of the ocean ensures that no location results will be returned.
+    // The `maxResults` parameter only applies to location searches, so this method passes the
+    // smallest valid value.
+    //
+    // TODO: Use a more appropriate API, when available.
+    [self getInstancesNearLatitude:0 longitude:0 user:user maxResults:1 distance:0 callback:callback];
+}
+
 -(void)getInstancesNearLatitude:(double)lat longitude:(double)lon user:(OTMUser *)user maxResults:(NSUInteger)max distance:(double)distance callback:(AZJSONCallback)callback {
 
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:

--- a/OpenTreeMap/src/OTM/OTMLocationManager.h
+++ b/OpenTreeMap/src/OTM/OTMLocationManager.h
@@ -26,6 +26,7 @@
 
 - (id)initWithDistanceRestriction:(BOOL)rd;
 - (void)findLocation:(void(^)(CLLocation *location, NSError *error))callback;
+- (void)findLocationWithAccuracy:(CLLocationAccuracy)accuracy callback:(void(^)(CLLocation*, NSError*))callback;
 - (void)stopFindingLocation;
 - (BOOL)locationServicesAvailable;
 

--- a/OpenTreeMap/src/OTM/OTMLocationManager.m
+++ b/OpenTreeMap/src/OTM/OTMLocationManager.m
@@ -38,6 +38,11 @@
 
 - (void)findLocation:(void(^)(CLLocation*, NSError*))callback
 {
+    [self findLocationWithAccuracy:kCLLocationAccuracyHundredMeters callback:callback];
+}
+
+- (void)findLocationWithAccuracy:(CLLocationAccuracy)accuracy callback:(void(^)(CLLocation*, NSError*))callback;
+{
     if (callback == nil) {
         return;
     }
@@ -45,7 +50,7 @@
 
         if (nil == [self locationManager]) {
             [self setLocationManager:[[CLLocationManager alloc] init]];
-            [[self locationManager] setDesiredAccuracy:kCLLocationAccuracyHundredMeters];
+            [[self locationManager] setDesiredAccuracy:accuracy];
         }
 
         [self setLocationFoundCallback:callback];


### PR DESCRIPTION
- Add a spinner to the right of the navigation bar whenever the app is waiting for the location manager to find the user's position or the app is waiting for a network response.

- Use a less precise accuracy requirement when trying to find the user's location in order to get a list of instances. 3000m is good enough given that our default instance radius is 5000m.

- Request the instances a user is a member of before attempting to find a nearby instance. Most users will only contribute to a single map and this ensures that map is available for selection as quickly as possible.

##### Testing

A spinner should always been shown when a location request or instance fetch request is in progress. 

You can use the location simulator in  the Xcode debugger pane to simulate a location fix both before and after the app is launched.

<img width="445" alt="screen shot 2016-01-13 at 9 45 58 pm" src="https://cloud.githubusercontent.com/assets/17363/12316088/e132eae8-ba3f-11e5-87db-2e4805c4467a.png">

<img width="442" alt="screen shot 2016-01-13 at 9 46 25 pm" src="https://cloud.githubusercontent.com/assets/17363/12316095/f31f206e-ba3f-11e5-9df1-5db0469b147e.png">

Specific locations can be added by creating GPX files and adding them to the Xcode location simulator.

```xml
<?xml version="1.0"?>
<gpx version="1.0" creator="">
  <wpt lat="34.044" lon="-118.249">
    <name>Los Angeles</name>
  </wpt>
</gpx>
```

---

Connects to #247 
