### PR TITLE
Support multichoice fields

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMChoicesDetailCellRenderer.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMChoicesDetailCellRenderer.h
@@ -22,11 +22,13 @@
 @property (nonatomic,strong) NSString *clickURL;
 @property (nonatomic,strong) NSString *fieldName;
 @property (nonatomic,strong) NSArray *fieldChoices;
+@property (nonatomic,assign) BOOL isMulti;
 
 -(id)initWithDataKey:(NSString *)datakey
                label:(NSString *)label
             clickUrl:(NSString *)clickurl
              choices:(NSArray *)choices
+             isMulti:(BOOL)ismulti
             writable:(BOOL)writable;
 
 @end
@@ -35,12 +37,10 @@
 
 -(id)initWithDetailRenderer:(OTMChoicesDetailCellRenderer *)aRenderer;
 
-@property (nonatomic,strong,readonly) NSString *output;
-
 @property (nonatomic,weak) OTMChoicesDetailCellRenderer *renderer;
 @property (nonatomic,strong) UITableViewController *controller;
 
-@property (nonatomic,strong) NSDictionary *selected;
+@property (nonatomic,strong) NSMutableSet *selectedValues;
 @property (nonatomic,strong,readonly) OTMDetailTableViewCell *cell;
 
 @end

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -56,20 +56,12 @@
 {
     self.originatingDelegate = delegate;
     NSMutableArray *cells = [[NSMutableArray alloc] init];
-    id elmt = [data decodeKey:self.dataKey];
     OTMCellSorter *sorterCell;
-    if ([elmt isKindOfClass:[NSArray class]]) {
-        for (id dataElement in elmt) {
-            sorterCell = (OTMCellSorter *)[self prepareCellSorterWithData:dataElement inTable:tableView];
-            [cells addObject:sorterCell];
-        }
+    sorterCell = (OTMCellSorter *)[self prepareCell:data inTable:tableView];
+    if (sorterCell) {
+        [cells addObject:sorterCell];
     } else {
-        sorterCell = (OTMCellSorter *)[self prepareCell:data inTable:tableView];
-        if (sorterCell) {
-            [cells addObject:sorterCell];
-        } else {
-            NSLog(@"No sorter cell found.");
-        }
+        NSLog(@"No sorter cell found.");
     }
     return [cells copy];
 }

--- a/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.h
@@ -106,5 +106,5 @@ extern NSString * const UdfDataChangedForStepNotification;
 + (NSString *)typeLabelFromType:(NSString *)type;
 + (NSString *)stringifyData:(id)data byType:(NSString *)type;
 + (NSString *)typeFromDataKey:(NSString *)dataKey;
-
++ (NSArray *)prepareAllCells:(NSDictionary *)data inCellRenderer:(id)cellRenderer inTable:(UITableView *)tableView withOriginatingDelegate:(UINavigationController *)delegate;
 @end

--- a/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.m
@@ -107,6 +107,11 @@ NSString * const UdfUpdateNotification = @"UdfUpdateNotification";
     [self.controller.navigationController popViewControllerAnimated:YES];
 }
 
+- (NSArray *)prepareAllCells:(NSDictionary *)data inTable:(UITableView *)tableView withOriginatingDelegate:(UINavigationController *)delegate
+{
+    return [OTMUdfCollectionHelper prepareAllCells:data inCellRenderer:self inTable:tableView withOriginatingDelegate:delegate];
+}
+
 - (OTMCellSorter *)prepareCellSorterWithData:(NSDictionary *)data
                                      inTable:(UITableView *)tableView
 {
@@ -589,6 +594,11 @@ NSString * const UdfDataChangedForStepNotification = @"UdfDataChangedForStepNoti
     return nil;
 }
 
+- (NSArray *)prepareAllCells:(NSDictionary *)data inTable:(UITableView *)tableView withOriginatingDelegate:(UINavigationController *)delegate
+{
+    return [OTMUdfCollectionHelper prepareAllCells:data inCellRenderer:self inTable:tableView withOriginatingDelegate:delegate];
+}
+
 - (OTMCellSorter *)prepareCellSorterWithData:(NSDictionary *)data
                                      inTable:(UITableView *)tableView
 {
@@ -759,6 +769,21 @@ NSString * const UdfDataChangedForStepNotification = @"UdfDataChangedForStepNoti
 {
     NSArray* keyList = [dataKey componentsSeparatedByString:@"."];
     return [keyList count] > 0 ? [[keyList objectAtIndex:0] capitalizedString] : nil;
+}
+
++ (NSArray *)prepareAllCells:(NSDictionary *)data inCellRenderer:(id)cellRenderer inTable:(UITableView *)tableView withOriginatingDelegate:(UINavigationController *)delegate
+{
+    [cellRenderer setOriginatingDelegate:delegate];
+    NSMutableArray *cells = [[NSMutableArray alloc] init];
+    if ([cellRenderer dataKey]) {
+        id elmt = [data decodeKey:[cellRenderer dataKey]];
+        OTMCellSorter *sorterCell;
+        for (id dataElement in elmt) {
+            sorterCell = (OTMCellSorter *)[cellRenderer prepareCellSorterWithData:dataElement inTable:tableView];
+            [cells addObject:sorterCell];
+        }
+    }
+    return [cells copy];
 }
 
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -435,6 +435,7 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
                                                             label:displayField
                                                          clickUrl:nil
                                                           choices:choices
+                                                          isMulti:[dType isEqualToString:@"multichoice"]
                                                          writable:writable];
 
         [modelFields addObject:renderer];


### PR DESCRIPTION
Editing single choice and multichoice fields have a similar workflow so, by adding a new `isMulti` property, the existing `OTMChoicesDetailCellRenderer` can conditionally handle both types of fields.

When stewardship support was added, the `OTMDetailCellRenderer` base class used `isKindOfClass [NSArray class]` to detect a collection UDF field. Multichoice fields are also stored as arrays, requiring that we refactor this logic.

The visible difference between the single select and multiselect mode is subtle, so I added a header to the table view with and instructive message.

The `stringForValue:` method is repeated in both `OTMChoicesDetailCellRenderer` and `OTMEditChoicesDetailCellRenderer` but it is so simple that trying to DRY it out would be more complicated.

##### Testing

- Create an instance with a single choice tree UDF and a multichoice tree UDF
- Use the console (or management page if that functionality is available) to add the two new tree UDFs to `instance.mobile_api_fields`
- In `Implementation.plist` set `APIURL.version` to `v4`
- Ensure that you can add and edit single choice and multichoice field values and that there are no regressions in stewardship adding and viewing

---

Connects to #232