### PR TITLE
Fix layout of "toggle" filters

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.h
@@ -64,10 +64,15 @@ typedef enum {
 
 @end
 
-@interface OTMBoolFilter : OTMFilter
+@interface OTMToggleFilter : OTMFilter
 
 @property (nonatomic,readonly) UILabel *nameLbl;
 @property (nonatomic,readonly) UISwitch *toggle;
+
+@end
+
+@interface OTMBoolFilter : OTMToggleFilter
+
 @property (nonatomic,readonly) BOOL existanceFilter;
 
 - (id)initWithName:(NSString *)nm key:(NSString *)k;
@@ -75,10 +80,8 @@ typedef enum {
 
 @end
 
-@interface OTMDefaultFilter : OTMFilter
+@interface OTMDefaultFilter : OTMToggleFilter
 
-@property (nonatomic, readonly) UILabel *nameLbl;
-@property (nonatomic, readonly) UISwitch *toggle;
 @property (nonatomic, readonly) NSString *defaultKey;
 @property (nonatomic, readonly) NSString *defaultValue;
 

--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
@@ -193,22 +193,7 @@
 
 @end
 
-@implementation OTMBoolFilter
-
-- (id)initWithName:(NSString *)nm key:(NSString *)k {
-    return [self initWithName:nm key:k existanceFilter:NO];
-}
-
-- (id)initWithName:(NSString *)nm key:(NSString *)k existanceFilter:(BOOL)existanceFilter {
-    self = [super init];
-    if (self) {
-        [self setName:nm];
-        [self setKey:k];
-        _existanceFilter = existanceFilter;
-    }
-
-    return self;
-}
+@implementation OTMToggleFilter
 
 - (UIView *)view {
     if (![self viewSet]) {
@@ -222,11 +207,11 @@
     const CGFloat viewMinHeight = 40;
     const CGFloat margin = 20; // space at left and right edges
     const CGFloat gutter = 10; // padding between label and toggle
-
+    
     // Compute right-aligned toggle position based on its size
     _toggle = [[UISwitch alloc] initWithFrame:CGRectZero];
     CGFloat toggleX = viewWidth - _toggle.frame.size.width - margin;
-
+    
     // Make a label using the remaining horizontal width
     CGFloat labelWidth = toggleX - margin - gutter;
     _nameLbl = [[UILabel alloc] initWithFrame:CGRectMake(margin + 1, 0, labelWidth, 0)];
@@ -234,23 +219,22 @@
     _nameLbl.lineBreakMode = NSLineBreakByWordWrapping;
     _nameLbl.numberOfLines = 0;
     _nameLbl.text = self.name;
-//    _nameLbl.text = [self.name stringByAppendingString:@", followed by a whole lot more text"];
-
+    
     // Wrap label text and get height, respecting viewMinHeight
     [_nameLbl sizeToFit];
     CGFloat labelHeight = MAX(_nameLbl.frame.size.height, viewMinHeight);
     _nameLbl.frame = CGRectMake(_nameLbl.frame.origin.x, _nameLbl.frame.origin.y,
                                 labelWidth, labelHeight);
-
+    
     // Center toggle vertically
     CGFloat toggleY = (int)((labelHeight - _toggle.frame.size.height) / 2.0);
     _toggle.frame = CGRectOffset(_toggle.frame, toggleX, toggleY);
-
+    
     CGRect viewFrame = CGRectMake(0, 0, viewWidth, labelHeight);
     [self setView:[[UIView alloc] initWithFrame:viewFrame]];
     [self.view addSubview:_nameLbl];
     [self.view addSubview:_toggle];
-
+    
     return self.view;
 }
 
@@ -262,12 +246,31 @@
     [_toggle setOn:NO animated:YES];
 }
 
+@end
+
+@implementation OTMBoolFilter
+
+- (id)initWithName:(NSString *)nm key:(NSString *)k {
+    return [self initWithName:nm key:k existanceFilter:NO];
+}
+
+- (id)initWithName:(NSString *)nm key:(NSString *)k existanceFilter:(BOOL)existanceFilter {
+    self = [super init];
+    if (self) {
+        [self setName:nm];
+        [self setKey:k];
+        _existanceFilter = existanceFilter;
+    }
+    
+    return self;
+}
+
 - (NSDictionary *)queryParams {
     if ([self active]) {
         if ([self existanceFilter]) {
             return @{ self.key: @{ @"ISNULL": @"true" }};
         } else {
-            return [NSDictionary dictionaryWithObjectsAndKeys:_toggle.on ? @"true" : @"false", self.key, nil];
+            return [NSDictionary dictionaryWithObjectsAndKeys:self.toggle.on ? @"true" : @"false", self.key, nil];
         }
     } else {
         return [NSDictionary dictionary];
@@ -308,43 +311,6 @@
 - (void)setDefaultValue:(NSString *)defaultValue
 {
     _defaultValue = defaultValue;
-}
-
-- (UIView *)view {
-    if (![self viewSet]) {
-        [self setView:[self createView]];
-    }
-    return [super view];
-}
-
-- (UIView *)createView {
-    CGRect r = CGRectMake(0,0,320,40);
-    [self setView:[[UIView alloc] initWithFrame:r]];
-
-    _nameLbl = [[UILabel alloc] initWithFrame:CGRectOffset(self.view.frame, 21, 0)];
-    _nameLbl.backgroundColor = [UIColor clearColor];
-    _nameLbl.textAlignment = UITextAlignmentLeft;
-    _nameLbl.text = self.name;
-
-    CGRect switchRect = CGRectMake(0,0,79,27); // this is the default (and only?) size for an iOS toggle switch
-    CGFloat rightPad = 20.0;
-    CGFloat ox = r.size.width - (rightPad + switchRect.size.width);
-    CGFloat oy = (int)((r.size.height - switchRect.size.height) / 2.0);
-
-    _toggle = [[UISwitch alloc] initWithFrame:CGRectOffset(switchRect, ox, oy)];
-
-    [self.view addSubview:_nameLbl];
-    [self.view addSubview:_toggle];
-
-    return self.view;
-}
-
-- (BOOL)active {
-    return _toggle.on;
-}
-
-- (void)clear {
-    [_toggle setOn:NO animated:YES];
 }
 
 - (NSDictionary *)queryParams {

--- a/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMFilterListViewController.m
@@ -218,21 +218,36 @@
 }
 
 - (UIView *)createView {
-    CGRect r = CGRectMake(0,0,320,40);
-    [self setView:[[UIView alloc] initWithFrame:r]];
+    const CGFloat viewWidth = 320;
+    const CGFloat viewMinHeight = 40;
+    const CGFloat margin = 20; // space at left and right edges
+    const CGFloat gutter = 10; // padding between label and toggle
 
-    _nameLbl = [[UILabel alloc] initWithFrame:CGRectOffset(self.view.frame, 21, 0)];
+    // Compute right-aligned toggle position based on its size
+    _toggle = [[UISwitch alloc] initWithFrame:CGRectZero];
+    CGFloat toggleX = viewWidth - _toggle.frame.size.width - margin;
+
+    // Make a label using the remaining horizontal width
+    CGFloat labelWidth = toggleX - margin - gutter;
+    _nameLbl = [[UILabel alloc] initWithFrame:CGRectMake(margin + 1, 0, labelWidth, 0)];
     _nameLbl.backgroundColor = [UIColor clearColor];
-    _nameLbl.textAlignment = UITextAlignmentLeft;
+    _nameLbl.lineBreakMode = NSLineBreakByWordWrapping;
+    _nameLbl.numberOfLines = 0;
     _nameLbl.text = self.name;
+//    _nameLbl.text = [self.name stringByAppendingString:@", followed by a whole lot more text"];
 
-    CGRect switchRect = CGRectMake(0,0,79,27); // this isthe default (and only?) size for an iOS toggle switch
-    CGFloat rightPad = 20.0;
-    CGFloat ox = r.size.width - (rightPad + switchRect.size.width);
-    CGFloat oy = (int)((r.size.height - switchRect.size.height) / 2.0);
+    // Wrap label text and get height, respecting viewMinHeight
+    [_nameLbl sizeToFit];
+    CGFloat labelHeight = MAX(_nameLbl.frame.size.height, viewMinHeight);
+    _nameLbl.frame = CGRectMake(_nameLbl.frame.origin.x, _nameLbl.frame.origin.y,
+                                labelWidth, labelHeight);
 
-    _toggle = [[UISwitch alloc] initWithFrame:CGRectOffset(switchRect, ox, oy)];
+    // Center toggle vertically
+    CGFloat toggleY = (int)((labelHeight - _toggle.frame.size.height) / 2.0);
+    _toggle.frame = CGRectOffset(_toggle.frame, toggleX, toggleY);
 
+    CGRect viewFrame = CGRectMake(0, 0, viewWidth, labelHeight);
+    [self setView:[[UIView alloc] initWithFrame:viewFrame]];
     [self.view addSubview:_nameLbl];
     [self.view addSubview:_toggle];
 


### PR DESCRIPTION
For each "toggle" filter:
* Right-justify toggle
* Use remaining space for label
* Wrap label to multiple lines if necessary
* Center toggle vertically with respect to label

Also DRY out duplicated code by adding `OTMToggleFilter` as superclass of `OTMBoolFilter` and `OTMDefaultFilter`.

Connects #268

##### Testing #####
1. Go to a tree map with alerts
2. Verify that both "Missing Data" toggles and "Alert" toggles are right justified
3. Replace this code:
```objective-c
_nameLbl.text = self.name;
```
with this code:
```objective-c
_nameLbl.text = [self.name stringByAppendingString:@", followed by a whole lot more text"];
```
4. Verify that the now-long labels wrap to 3 lines, don't overlap the toggles, and that the toggles are vertically centered.
5. Verify that both the "Missing Data" and "Alert" filters still work.