### PR TITLE
Remove filters from map tap nearby plot request

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -613,7 +613,6 @@
     [[[OTMEnvironment sharedEnvironment] api] getPlotsNearLatitude:coordinate.latitude
                    longitude:coordinate.longitude
                         user:loginManager.loggedInUser
-                     filters:self.filters
                     callback:^(NSArray* plots, NSError* error)
      {
          if ([plots count] == 0) { // No plots returned


### PR DESCRIPTION
The /location/lat,lng/plots API endpoint ignores any filters that are passed along with the request:

https://github.com/OpenTreeMap/otm-core/blob/983ffcdb0a226fc9bd6ab1fc3e3f42e47ed9e5ba/opentreemap/api/plots.py#L39

The filters have been ignored since the initial creation of the OTM2 API endpoint.

https://github.com/OpenTreeMap/otm-core/commit/b25c3b9dc90f83f6e5abc67b7396bcdc7f2cefde

---

##### Testing

If you run the application in the simulator, apply a filter, and then tap the map, you should see in the NSLog output that the request is sent without a `q=` parameter.

The specific bug resolved by this commit can be tested for by following the reproduction steps from #278:

On the website:

1. Create a custom planting site field named "Test Field". Make it editable and filterable on mobile.
1. Add a planting site and set the value of "Test Field"

On the iOS app:

1. Find the newly created planting site and verify that you can tap it and see its detail popup. Tap away from the planting site to clear the selection.
1. Filter the map by "Test Field" so that it will match the value used when creating the planting site.
1. Tap the planting site, which should still be visible because it matches the filter.

On the current `master` branch, the popup will not appear because the filters passed along to the endpoint are not encoded using a method consistent with what the server expects, resulting in a 400 response.

---

Connects to #278 
