### PR TITLE
Allow selecting instance if previous instance fails to load

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMSplashViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMSplashViewController.m
@@ -34,33 +34,33 @@
 - (void)loadInstance {
     OTMLoginManager* loginManager = [SharedAppDelegate loginManager];
     AZUser* user = [loginManager loggedInUser];
-
+    
     OTM2API *api = [[OTMEnvironment sharedEnvironment] api2];
     NSString *instance = [[OTMEnvironment sharedEnvironment] instance];
     [api loadInstanceInfo:instance
                   forUser:user
              withCallback:^(id json, NSError *error) {
-
-        if (error != nil) {
-          [UIAlertView showAlertWithTitle:nil
-                                  message:@"There was a problem connecting to the server. Hit OK to try again."
-                        cancelButtonTitle:@"OK"
-                         otherButtonTitle:nil
-                                 callback:^(UIAlertView *alertView, int btnIdx)
-                       {
-                         [self loadInstance];
-                       }];
-        } else {
-          [[OTMEnvironment sharedEnvironment] updateEnvironmentWithDictionary:json];
-            [self afterSplashDelaySegueTo:@"startWithInstance"];
-        }
-      }];
+                 
+                 if (error != nil) {
+                     [UIAlertView showAlertWithTitle:nil
+                                             message:@"There was a problem connecting to the server. Hit OK to try again."
+                                   cancelButtonTitle:@"OK"
+                                    otherButtonTitle:nil
+                                            callback:^(UIAlertView *alertView, int btnIdx)
+                      {
+                          [self loadInstance];
+                      }];
+                 } else {
+                     [[OTMEnvironment sharedEnvironment] updateEnvironmentWithDictionary:json];
+                     [self afterSplashDelaySegueTo:@"startWithInstance"];
+                 }
+             }];
 }
 
 - (void)afterSplashDelaySegueTo:(NSString *)segueName
 {
     NSTimeInterval seconds = self.triggerTime - [[NSDate date] timeIntervalSince1970];
-
+    
     dispatch_time_t tgt = dispatch_time(DISPATCH_TIME_NOW, seconds * NSEC_PER_SEC);
     dispatch_after(tgt, dispatch_get_main_queue(), ^{
         [self performSegueWithIdentifier:segueName sender:self];
@@ -70,12 +70,12 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
+    
     NSTimeInterval seconds = [[OTMEnvironment sharedEnvironment] splashDelayInSeconds];
     self.triggerTime = [[NSDate date] timeIntervalSince1970] + seconds;
-
+    
     NSString *instance = [[OTMEnvironment sharedEnvironment] instance];
-
+    
     if ([[OTMEnvironment sharedEnvironment] allowInstanceSwitch]) {
         instance = [[OTMPreferences sharedPreferences] instance];
         if (instance && ![instance isEqualToString:@""]) {
@@ -84,11 +84,11 @@
         } else {
             [self afterSplashDelaySegueTo:@"selectInstance"];
         }
-
+        
     } else {
-       [self loadInstance];
+        [self loadInstance];
     }
-
+    
 }
 
 - (void)viewDidUnload

--- a/OpenTreeMap/src/OTM/Controllers/OTMSplashViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMSplashViewController.m
@@ -15,6 +15,7 @@
 
 #import "OTMSplashViewController.h"
 #import "OTMPreferences.h"
+#import <Rollbar/Rollbar.h>
 
 @interface OTMSplashViewController ()
 
@@ -42,14 +43,19 @@
              withCallback:^(id json, NSError *error) {
                  
                  if (error != nil) {
-                     [UIAlertView showAlertWithTitle:nil
-                                             message:@"There was a problem connecting to the server. Hit OK to try again."
-                                   cancelButtonTitle:@"OK"
-                                    otherButtonTitle:nil
-                                            callback:^(UIAlertView *alertView, int btnIdx)
-                      {
-                          [self loadInstance];
-                      }];
+                     [Rollbar warningWithMessage:[NSString stringWithFormat:@"Failed to load instance '%@'",instance]];
+                     if ([[OTMEnvironment sharedEnvironment] allowInstanceSwitch]) {
+                         [self afterSplashDelaySegueTo:@"selectInstance"];
+                     } else {
+                         [UIAlertView showAlertWithTitle:nil
+                                                 message:@"There was a problem connecting to the server. Hit OK to try again."
+                                       cancelButtonTitle:@"OK"
+                                        otherButtonTitle:nil
+                                                callback:^(UIAlertView *alertView, int btnIdx)
+                          {
+                              [self loadInstance];
+                          }];
+                     }
                  } else {
                      [[OTMEnvironment sharedEnvironment] updateEnvironmentWithDictionary:json];
                      [self afterSplashDelaySegueTo:@"startWithInstance"];


### PR DESCRIPTION
Also:
* Log warning to Rollbar that we failed to load an instance
* For skinned apps (where selecting an instance is disabled), show error dialog as we did before

Connects #287

To test:
1) Open a tree map
2) Exit the app (cmd+shift+h twice and swipe up)
3) Rename the instance in super admin
4) Launch the app

You should see a warning in rollbar, and the app should show the instance switcher.