### PR TITLE
Only show "Add" (tree) button if user has the required permissions

### DIFF
--- a/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
+++ b/OpenTreeMap/resources/MainStoryboard_iPhone.storyboard
@@ -159,7 +159,6 @@
                                 <segue destination="5L2-2I-7tO" kind="modal" identifier="filtersList" id="cgy-qy-I9w"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="Add" id="kSh-FL-AwC"/>
                     </navigationItem>
                     <connections>
                         <outlet property="addTreeHelpLabel" destination="WkD-Gf-Dze" id="v5o-zG-gmM"/>

--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -172,6 +172,15 @@
             [self startFindingLocation:self];
         }
     }
+    if (self.mode == Select) {
+        if ([[OTMEnvironment sharedEnvironment] canAddTree]) {
+            self.navigationItem.rightBarButtonItem.enabled = true;
+            self.navigationItem.rightBarButtonItem.title = @"Add";
+        } else {
+            self.navigationItem.rightBarButtonItem.enabled = false;
+            self.navigationItem.rightBarButtonItem.title = nil;
+        }
+    }
 }
 
 /**

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -140,6 +140,7 @@ extern NSString * const OTMEnvironmentDateStringShort;
 @property (nonatomic, strong) NSURL *instanceLogoUrl;
 @property BOOL speciesFieldWritable;
 @property BOOL photoFieldWritable;
+@property BOOL canAddTree;
 
 
 // Security

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -206,6 +206,7 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
     self.sectionTitles = [self sectionTitlesFromDictArray:[dict objectForKey:@"field_key_groups"]];
     self.config = [dict objectForKey:@"config"];
     self.mapViewTitle = [dict objectForKey:@"name"];
+    self.canAddTree = [[[[dict objectForKey:@"meta_perms"] objectForKey:@"can_add_tree"] stringValue] isEqualToString:@"0"] ? NO : YES;
     self.photoFieldWritable = [[[[self.fieldData objectForKey:@"treephoto.image"] objectForKey:@"can_write"] stringValue] isEqualToString:@"0"] ? NO : YES;
     [self setSearchRegionRadiusInMeters:[[dict objectForKey:@"extent_radius"] doubleValue]];
 


### PR DESCRIPTION
Currently the web app allows a user to add a tree if they have write permission on certain plot fields (see e.g https://github.com/OpenTreeMap/otm-core/blob/develop/opentreemap/treemap/audit.py#L496), currently just `geom`.

The results are included in the initial environment dictionary, as `dict.meta_fields.can_edit_tree`. So show the "Add" button only if the user has that "meta permission".

Logic is in `viewWillAppear` so it will change if the user logs out and logs back in as a user with different permissions.

Connects #109
Connects #296