### PR TITLE
Read Rollbar environment from Implementation.plist

### DIFF
--- a/OpenTreeMap/src/OTM/OTMAppDelegate.m
+++ b/OpenTreeMap/src/OTM/OTMAppDelegate.m
@@ -42,12 +42,9 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeEnvironment:) name:kOTMEnvironmentChangeNotification object:nil];
 
-    NSString *rollbarClientAccessToken = [[OTMEnvironment sharedEnvironment] rollbarClientAccessToken];
-    if (rollbarClientAccessToken) {
-        [Rollbar initWithAccessToken:rollbarClientAccessToken];
+    if ([self configureRollbarWithEnvironment:[OTMEnvironment sharedEnvironment]])
+    {
         [Rollbar debugWithMessage:@"iOS application launched"];
-    } else {
-        NSLog(@"Skipping Rollbar initialization - No client access token configured");
     }
 
     return YES;
@@ -101,6 +98,22 @@
     OTMEnvironment *env = note.object;
     self.window.tintColor = env.primaryColor;
     self.window.backgroundColor = [UIColor whiteColor];
+}
+
+#pragma mark Helpers
+
+- (BOOL) configureRollbarWithEnvironment:(OTMEnvironment*)env
+{
+    NSString *rollbarClientAccessToken = [env rollbarClientAccessToken];
+    if (rollbarClientAccessToken) {
+        RollbarConfiguration *config = [RollbarConfiguration configuration];
+        config.environment = env.environmentName ?: config.environment;
+        [Rollbar initWithAccessToken:rollbarClientAccessToken configuration:config];
+        return YES;
+    } else {
+        NSLog(@"Skipping Rollbar initialization - No client access token configured");
+        return NO;
+    }
 }
 
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -151,6 +151,7 @@ extern NSString * const OTMEnvironmentDateStringShort;
 @property (nonatomic, strong) NSString *inappropriateReportEmail;
 
 // Crash reporting
+@property (nonatomic, strong) NSString *environmentName;
 @property (nonatomic, strong) NSString *rollbarClientAccessToken;
 
 

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -136,6 +136,7 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
         self.inappropriateReportEmail = @"OpenTreeMap <info@opentreemap.org>";
     }
 
+    self.environmentName = [implementation objectForKey:@"environmentName"];
     self.rollbarClientAccessToken = [implementation objectForKey:@"RollbarClientAccessToken"];
 
     OTM2API* otmApi = [[OTM2API alloc] init];


### PR DESCRIPTION
By default Rollbar logs all items as "development." Adding a new Implementation.plist key allows for staging or production builds to log events under the appropriate environment name.

---

##### Testing

Make sure the application runs properly without the additional `environmentName` key in `Implementation.plist`

Launch the app with different values of `environmentName` and verify that items appear in Rollbar with the correct environment.

---

Depends on https://github.com/OpenTreeMap/otm-mobile-skins/pull/76
Connects to https://github.com/OpenTreeMap/otm-ios/issues/295