### PR TITLE
Update cell correctly when choosing a species for a new tree

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
@@ -198,6 +198,7 @@ ABSTRACT_METHOD
 @property (nonatomic,strong) NSString *defaultName;
 @property (nonatomic,strong) NSString *name;
 @property (nonatomic,strong) id data;
+@property (nonatomic,strong,readonly) UITableViewCell *detailcell;
 
 @end
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -415,7 +415,7 @@
 
 #define kOTMDetailEditSpeciesCellRendererCellId @"kOTMDetailEditSpeciesCellRendererCellId"
 
-@synthesize name, data, defaultName;
+@synthesize name, data, defaultName, detailcell;
 
 - (id)initWithKey:(NSString *)key clickCallback:(Function2v)aCallback {
     return [self initWithName:nil key:key clickCallback:aCallback];
@@ -441,11 +441,12 @@
 - (OTMCellSorter *)prepareCell:(NSDictionary *)renderData
                        inTable:(UITableView *)tableView
 {
-    UITableViewCell *detailcell = [tableView dequeueReusableCellWithIdentifier:kOTMDetailEditSpeciesCellRendererCellId];
-
     if (!detailcell) {
-        detailcell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle
-                                            reuseIdentifier:kOTMDetailEditSpeciesCellRendererCellId];
+        detailcell = [tableView dequeueReusableCellWithIdentifier:kOTMDetailEditSpeciesCellRendererCellId];
+        if (!detailcell) {
+            detailcell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                                reuseIdentifier:kOTMDetailEditSpeciesCellRendererCellId];
+        }
     }
 
     if (name == nil) {

--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -963,38 +963,16 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
 {
     NSString *label = [@"Set Species" stringByAppendingFormat:@" (%@)", speciesString];
 
-    // Find the index of the set species cell.
-    NSIndexPath *indexPath = [self updateSpeciesEditCellLabelWithString:label];
-
-    if (indexPath != nil) {
-        [self.tableView beginUpdates];
-        [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath]
-                              withRowAnimation:UITableViewRowAnimationNone];
-        [self.tableView endUpdates];
-    }
-}
-
-/**
- * Update the set species edit cell rederer so that if the cell is re-rendered a
- * new label will appear. If the cell is in the list of current fields return
- * its index path.
- *
- * Return nil if the cell was not found.
- */
-- (NSIndexPath *) updateSpeciesEditCellLabelWithString:(NSString *) newLabel
-{
     // Loop through all the current cells until the species_name data key is
     // found. If it is update the label and return the indexpath.
     for (int i = 0; i < [curFields count]; i++) {
         for (int j = 0; j < [[[curFields objectAtIndex:i] valueForKey:@"cells"] count]; j++) {
             OTMStaticClickCellRenderer *cell = [[[curFields objectAtIndex:i] valueForKey:@"cells"] objectAtIndex:j];
             if ([[cell dataKey] isEqualToString:@"tree.species_name"]) {
-                cell.defaultName = newLabel;
-                return [NSIndexPath indexPathForItem:j inSection:i];
+                cell.detailcell.textLabel.text = label;
             }
         }
     }
-    return nil;
 }
 
 


### PR DESCRIPTION
The `OTMStaticClickCellRenderer` now hangs on to its `detailcell` and the `OTMTreeDetailViewController` updates the
`detailcell`'s label directly.

Connects #281