### PR TITLE
Change property attributes on OTMPreferences

### DIFF
--- a/OpenTreeMap/src/OTM/OTMPreferences.h
+++ b/OpenTreeMap/src/OTM/OTMPreferences.h
@@ -19,7 +19,7 @@
 
 + (OTMPreferences *)sharedPreferences;
 
-@property (assign) NSString *instance;
+@property (nonatomic, strong) NSString *instance;
 
 - (void)save;
 - (void)load;


### PR DESCRIPTION
The app was crashing with an `EXC_BAD_ACCESS` exception when the app delegate's `applicationDidEnterBackground:` method attempted to call `save` on `OTMPreferences`. Setting a breakpoint on unhandled exceptions revealed that the value of the `instance` property was invalid. It looks like this is the result of using the `assign` attribute, which should only be used on primitive types (int, BOOL, etc.).

I am not able to reproduce the exception after replacing `assign` with our app-wide convention for string properties, `nonatomic` and `strong`.

---

##### Testing

Follow the reproduction steps in #323.

---

Connects to #323 