### PR TITLE
Add camera and photo library usage messages

### DIFF
--- a/OpenTreeMap/OpenTreeMap-Info.plist.template
+++ b/OpenTreeMap/OpenTreeMap-Info.plist.template
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	  <key>NSLocationWhenInUseUsageDescription</key>
-	  <string>OpenTreeMap uses your location to find trees near you.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Select and upload photos of trees you have already taken.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Use the camera to take photos of trees.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>OpenTreeMap uses your location to find trees near you.</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>


### PR DESCRIPTION
Versions of the application built with Xcode 8 crash on iOS 10 when trying to access the camera or photo library unless we provide messages to be shown to the user.

This Apple documentation page confirms that both of these new keys are available in our target OS version, iOS 7.1+
https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html

---

##### Testing

Check out the `master` branch, build it with Xcode 8, and run it on a physical device with iOS 10+ installed. You should see the application crash when you attempt to add a photo from the camera or the photo library. Repeat the process on this branch and the crashes should be resolved.

--- 

Connects to #328 