### PR TITLE
Use correct info to enable/disable adding tree photos

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -277,7 +277,7 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
         speciesRow.detailDataKey = @"tree.sci_name";
     }
 
-    if ([[OTMEnvironment sharedEnvironment] photoFieldIsWritable]) {
+    if ([[OTMEnvironment sharedEnvironment] canAddTreePhoto]) {
         pictureRow = [[OTMStaticClickCellRenderer alloc]
                       initWithName:@"Tree Picture"
                                key:@""

--- a/OpenTreeMap/src/OTM/OTMEnvironment.h
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.h
@@ -139,7 +139,7 @@ extern NSString * const OTMEnvironmentDateStringShort;
 @property (nonatomic, strong) NSDictionary* config;
 @property (nonatomic, strong) NSURL *instanceLogoUrl;
 @property BOOL speciesFieldWritable;
-@property BOOL photoFieldWritable;
+@property BOOL canAddTreePhoto;
 @property BOOL canAddTree;
 
 
@@ -164,6 +164,5 @@ extern NSString * const OTMEnvironmentDateStringShort;
 - (NSString *)absolutePhotoUrlFromPhotoUrl:(NSString *)url;
 
 - (BOOL) speciesFieldIsWritable;
-- (BOOL) photoFieldIsWritable;
 
 @end

--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -210,7 +210,7 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
     self.config = [dict objectForKey:@"config"];
     self.mapViewTitle = [dict objectForKey:@"name"];
     self.canAddTree = [[[[dict objectForKey:@"meta_perms"] objectForKey:@"can_add_tree"] stringValue] isEqualToString:@"0"] ? NO : YES;
-    self.photoFieldWritable = [[[[self.fieldData objectForKey:@"treephoto.image"] objectForKey:@"can_write"] stringValue] isEqualToString:@"0"] ? NO : YES;
+    self.canAddTreePhoto = [[[[dict objectForKey:@"meta_perms"] objectForKey:@"can_edit_tree_photo"] stringValue] isEqualToString:@"0"] ? NO : YES;
     [self setSearchRegionRadiusInMeters:[[dict objectForKey:@"extent_radius"] doubleValue]];
 
     NSDictionary *missingAndStandardFilters = [dict objectForKey:@"search"];
@@ -668,10 +668,6 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
 
 - (BOOL) speciesFieldIsWritable {
     return self.speciesFieldWritable;
-}
-
-- (BOOL) photoFieldIsWritable {
-    return self.photoFieldWritable;
 }
 
 //


### PR DESCRIPTION
Use `meta_perms["can_edit_tree_photo"]` (as the Android app does), which respects new-style permissions.

Testing:
1. Add a tree and verify that The "Picture" field says "Tree Picture"
1. Turn off the "Can Add Tree Photo" permission for the user's role
1. Add a tree and verify that The "Picture" field says "Picture cannot be changed"

Connects OpenTreeMap/otm-clients#334