### PR TITLE
Update photo report email view controller usage

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMImageViewController.m
@@ -87,11 +87,20 @@
 
 - (IBAction)reportInappropriate:(id)sender
 {
-    NSDictionary *photo = [OTMTreeDictionaryHelper getLatestPhotoInDictionary:self.data];
-    OTMInappropriateContentMailViewController *mailViewController =
+    if ([OTMInappropriateContentMailViewController canSendMail]) {
+        NSDictionary *photo = [OTMTreeDictionaryHelper getLatestPhotoInDictionary:self.data];
+        OTMInappropriateContentMailViewController *mailViewController =
         [[OTMInappropriateContentMailViewController alloc] initWithPhotoDictionary:photo];
-    mailViewController.mailComposeDelegate = self;
-    [self presentModalViewController:mailViewController animated:YES];
+        mailViewController.mailComposeDelegate = self;
+        [self presentViewController:mailViewController animated:YES completion:nil];
+    } else {
+        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Mail Not Configured"
+                                                            message:@"Please set up mail before reporting an inappropriate photo."
+                                                           delegate:nil
+                                                  cancelButtonTitle:@"OK"
+                                                  otherButtonTitles:nil];
+        [alertView show];
+    }
 }
 
 # pragma mark MFMailComposeViewControllerDelegate


### PR DESCRIPTION
- Replace deprecated `presentModalViewController` with `presentViewController`.
- Check the `canSendMail` static method before attempting to use the
`OTMInappropriateContentMailViewController` to present a view controller. This
prevents a crash when email has not been configured on the device.

---

##### Testing

- Run the app in the simulator
  - Create a tree with a photo
  - Re-select the tree on the map page and tap the photo
  - Tap report. You should see a dialog instead of crashing
- Run the app on a device with a configured email account
  - Create a tree with a photo
  - Re-select the tree on the map page and tap the photo
  - Tap report. A draft email view should appear with the tree and photo details.

---

Connects to #312 