### PR TITLE
Exclude readonly when saving tree/plot.

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -765,7 +765,8 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
 - (NSMutableDictionary *)getWritableFieldData {
     NSMutableDictionary *writableData = [[NSMutableDictionary alloc] init];
     NSDictionary *fieldData = [[OTMEnvironment sharedEnvironment] fieldData];
-
+    // readonly is not implemented
+    NSArray *excludedFields = @[@"tree.readonly", @"plot.readonly"];
     for (NSString *model in @[@"plot", @"tree"]) {
         NSDictionary *modelData = self.data[model];
     
@@ -776,7 +777,9 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
                 NSString *fieldKey = [NSString stringWithFormat:@"%@.%@", model, key];
                 NSDictionary *field = fieldData[fieldKey];
             
-                if (field != nil && ([key isEqualToString:@"id"] || [field[@"can_write"] boolValue])) {
+                if (field != nil
+                    && ![excludedFields containsObject:fieldKey]
+                    && ([key isEqualToString:@"id"] || [field[@"can_write"] boolValue])) {
                     writableModelData[key] = modelData[key];
                 }
             }


### PR DESCRIPTION
`readonly` is a special field that has not been implemented in the backend. Editing an empty planting site was incorrectly creating a tree because the app was sending "false" for the value of `tree.readonly`. The simplest way to handle this was to simply filter out the `readonly` field before PUTing/POSTing to the API.

---

##### Testing

- Log in as an user in the Administrator role for an instance.
- Add an empty plot.
- Edit the plot then tap "Done" without changing any values. Verify that a tree was not created.

---

Connects to #284