### PR TITLE
Update date field handling

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.h
@@ -81,6 +81,16 @@
 
 @property (nonatomic, strong) UIViewController *originatingDelegate;
 
+/**
+ * The original string value of the cell when it was built
+ */
+@property (nonatomic,strong) NSString *initialCellDisplayValue;
+
+/**
+ * Set to YES whenever the value of the cell is cleared by the user.
+ */
+@property (nonatomic,assign) BOOL wasCleared;
+
 - (id)initWithDataKey:(NSString *)dkey;
 - (id)initWithDataKey:(NSString *)dkey editRenderer:(OTMEditDetailCellRenderer *)edit;
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -302,12 +302,9 @@
     }
 
     if (self.isDateField) {
-        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:OTMEnvironmentDateStringShort];
-        NSDate *originalDate =[dateFormatter dateFromString:value];
+        NSDate *originalDate = [self dateFromOTMDateString:value];
         [detailcell setDatePickerInputWithInitialDate:originalDate];
         disp = [detailcell formatHumanReadableDateStringFromDate:originalDate];
-
     }
 
     detailcell.editFieldValue.text = disp;
@@ -332,6 +329,18 @@
     detailcell.unitLabel.text = _formatter.label;
     self.wasCleared = NO;
     self.inited = YES;
+}
+
+-(NSDate *)dateFromOTMDateString:(NSString *)dateString
+{
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:OTMEnvironmentDateStringShort];
+    NSDate *newDate=[dateFormatter dateFromString:dateString];
+    if (!newDate) {
+        [dateFormatter setDateFormat:OTMEnvironmentDateStringLong];
+        newDate = [dateFormatter dateFromString:dateString];
+    }
+    return newDate;
 }
 
 @end

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -20,7 +20,7 @@
 
 @implementation OTMDetailCellRenderer
 
-@synthesize dataKey, editCellRenderer, newCellBlock, clickCallback, cellHeight, detailDataKey, ownerDataKey;
+@synthesize dataKey, editCellRenderer, newCellBlock, clickCallback, cellHeight, detailDataKey, ownerDataKey, initialCellDisplayValue, wasCleared;
 
 - (id)init {
     self = [super init];
@@ -234,15 +234,19 @@
 {
     if ([v isEqualToString:@""]) {
         self.updatedString = nil;
+        self.wasCleared = YES;
     } else {
         self.updatedString = v;
+        self.wasCleared = NO;
     }
 }
 
 - (NSDictionary *)updateDictWithValueFromCell:(NSDictionary *)dict {
     if (updatedString) {
         [dict setObject:updatedString forEncodedKey:self.dataKey];
-    } else {
+    } else if (self.initialCellDisplayValue && self.wasCleared) {
+        // If the cell was built with an initial value, and was updated to be empty, we want to return a null to
+        // signal that we want the value to be removed.
         [dict setObject:[NSNull null] forEncodedKey:self.dataKey];
     }
     updatedString = nil;
@@ -308,6 +312,7 @@
 
     detailcell.editFieldValue.text = disp;
     detailcell.fieldLabel.text = self.label;
+    self.initialCellDisplayValue = disp;
 
     /**
      * Edit cells don't have a fieldValue like the normal detail cell. We
@@ -325,6 +330,7 @@
                                              );
 
     detailcell.unitLabel.text = _formatter.label;
+    self.wasCleared = NO;
     self.inited = YES;
 }
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailCellRenderer.m
@@ -242,8 +242,10 @@
 - (NSDictionary *)updateDictWithValueFromCell:(NSDictionary *)dict {
     if (updatedString) {
         [dict setObject:updatedString forEncodedKey:self.dataKey];
-        updatedString = nil;
+    } else {
+        [dict setObject:[NSNull null] forEncodedKey:self.dataKey];
     }
+    updatedString = nil;
 
     return dict;
 }

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.h
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.h
@@ -33,12 +33,14 @@
 @property (nonatomic, assign) UIKeyboardType keyboardType;
 @property (nonatomic, copy) NSString *formatKey;
 @property (nonatomic, strong) UIDatePicker *picker;
+@property (nonatomic, strong) UIToolbar *pickerToolbar;
 
 @property (nonatomic, weak) id<UITextFieldDelegate> tfDelegate;
 @property (nonatomic, weak) id<OTMDetailTableViewCellDelegate> delegate;
 
 -(void)setDatePickerInput;
 -(void)setDatePickerInputWithInitialDate:(NSDate *)initDate;
+-(void)clearDatePicker:(id)sender;
 
 -(NSString*)formatHumanReadableDateStringFromString:(NSString*)dateString;
 -(NSString*)formatHumanReadableDateStringFromDate:(NSDate*)date;

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.m
@@ -99,6 +99,13 @@
     setDatePickerInputWithInitialDate:nil;
 }
 
+- (void)clearDatePicker:(id)sender
+{
+    self.editFieldValue.text = @"";
+    [delegate tableViewCell:self textField:self.editFieldValue updatedToValue:@""];
+    [self.editFieldValue resignFirstResponder];
+}
+
 -(void)setDatePickerInputWithInitialDate:(NSDate *)initDate
 {
     _picker = [[UIDatePicker alloc] init];
@@ -111,6 +118,14 @@
     [self.editFieldValue setFrame:frame];
     [_picker addTarget:self action:@selector(updateTextFieldWithDate:) forControlEvents:UIControlEventValueChanged];
 
+    _pickerToolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, 44)];
+    _pickerToolbar.barStyle = UIBarStyleDefault;
+    _pickerToolbar.userInteractionEnabled = YES;
+    UIBarButtonItem *flexibleSpaceLeft = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+    UIBarButtonItem* clearButton = [[UIBarButtonItem alloc] initWithTitle:@"Clear" style:UIBarButtonItemStyleDone target:self action:@selector(clearDatePicker:)];
+
+    [_pickerToolbar setItems:[NSArray arrayWithObjects:flexibleSpaceLeft, clearButton, nil]];
+    self.editFieldValue.inputAccessoryView = _pickerToolbar;
 }
 
 - (UILabel*)labelWithFrame:(CGRect)rect {
@@ -141,6 +156,9 @@
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField
 {
+    if ([self.editFieldValue.text isEqual:@""]) {
+        [self updateTextFieldWithDate:_picker];
+    }
     [tfDelegate textFieldDidBeginEditing:textField];
 }
 

--- a/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMDetailTableViewCell.m
@@ -81,6 +81,10 @@
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:OTMEnvironmentDateStringShort];
     NSDate *newDate=[dateFormatter dateFromString:dateString];
+    if (!newDate) {
+        [dateFormatter setDateFormat:OTMEnvironmentDateStringLong];
+        newDate = [dateFormatter dateFromString:dateString];
+    }
     [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
     [dateFormatter setTimeStyle:NSDateFormatterNoStyle];
     return [dateFormatter stringFromDate:newDate];


### PR DESCRIPTION
Before this commit setting the value of a date field to the current date required changing the date picker to some other value and then changing it back to the current date. This commit fixes that workflow by setting the date field value on focus and adding a toolbar with a "Clear" button to remove the value if it was set accidentally.

To properly clear a previously saved date value required changing the implementation of `updateDictWithValueFromCell:` to set an `NSNull` in the dictionary rather than omitting the key from the dictionary entirely.

The `updatedString` property is nil in two situations, the field was initially empty or an initially non-empty field was cleared. To remove the ambiguity I added two new properties to keep track of the initial value of the field and whether or not it was cleared by the user.

Some date strings include a `00:00` time that was causing string to date object conversions to fail. We have implemented a simple solution, falling back to trying to parse the date+time format if parsing the date-only format returns nil.

---

##### Testing

- On a test instance, add one of each type of custom field to the Tree model.

###### Date default and clear button

- Create a tree and tap to focus on the `Date Planted` field. Save the tree and verify that the current date is saved as the value of `Date Planted`
- Edit the tree, tap to focus on the `Date Planted` field, and click the `Clear` button. Save the tree and verify that the value has been removed from the tree.

###### Persistence, clearing, and display

- Add a tree and set a value in all of the custom fields.
- Save, deselect the tree, select the tree, view the details and verify that all values display correctly.
- Edit the tree and clear each custom field value one at a time. Save and reload the tree and verify that the field values have been cleared.

---

Connects to #217 
Connects to #357