### PR TITLE
Fix the workflow when a tree is created but photo saving fails

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMMapViewController.m
@@ -970,6 +970,11 @@
 - (void)disruptCoordinate:(CLLocationCoordinate2D)coordinate {
 }
 
+- (void)viewController:(OTMTreeDetailViewController *)viewController addedTree:(NSDictionary *)details
+{
+    [self viewController:viewController addedTree:details withPhoto:nil];
+}
+
 - (void)viewController:(OTMTreeDetailViewController *)viewController addedTree:(NSDictionary *)details withPhoto:(UIImage *)photo
 {
     [self changeMode:Select];

--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -205,6 +205,24 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
      }];
 }
 
+- (void)clearLastPicture {
+    NSArray *photos = [data objectForKey:@"images"];
+    UIImage *defaultImage = [UIImage imageNamed:@"Default_feature-image"];
+    if (photos != nil) {
+        // Taking a photo adds it to the "data.photos" array so we need to remove it
+        NSMutableArray *newPhotos = [NSMutableArray arrayWithArray:photos];
+        [newPhotos removeLastObject];
+        [data setObject:newPhotos forKey:@"images"];
+        if ([newPhotos count] > 0) {
+            self.imageView.image = [newPhotos lastObject];
+        } else {
+            self.imageView.image = defaultImage;
+        }
+    } else {
+        self.imageView.image = defaultImage;
+    }
+}
+
 - (void)setKeys:(NSArray *)k
 {
     _fieldsWithSectionTitles = [[NSMutableArray alloc] init];
@@ -913,13 +931,26 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
                    [self pushImageData:rest newTree:newTree latestImage:image];
                } else {
                    [[AZWaitingOverlayController sharedController] hideOverlay];
+                   [self clearLastPicture];
+                   NSString *message;
+                   if (newTree) {
+                       message = @"The planting site/tree was created, but there was a problem saving the photo.\n\nYou can edit the tree and try adding the photo again.";
+                   } else {
+                       message = @"There was a problem saving the updated tree photo.";
+                   }
                    NSLog(@"Error adding photo to tree: %@\n %@", err, data);
                    [[[UIAlertView alloc] initWithTitle:nil
-                                               message:@"Sorry. There was a problem saving the updated tree photos."
+                                               message:message
                                               delegate:nil
                                      cancelButtonTitle:@"OK"
                                      otherButtonTitles:nil] show];
-
+                   if (newTree) {
+                       [self.delegate viewController:self addedTree:data];
+                   } else {
+                       [delegate viewController:self editedTree:(NSDictionary *)data withOriginalLocation:originalLocation originalData:originalData];
+                       [self syncTopData];
+                       [self.tableView reloadData];
+                   }
                }
            }];
     }


### PR DESCRIPTION
Previous to these changes a failure to save an image put the application into an inconsistent state. After showing an error message, the map page was still in the "add tree" mode with the movable marker appearing on the map.

These changes address that problem by calling slightly different versions the same post-save actions. We have added a separate and more helpful error message in the case when saving the photo of a new tree fails vs. when adding a photo to an existing tree fails.

We have also implemented `viewController:addedTree:` in `OTMMapViewController.m`. That method was defined in the `.h` file but the implementation was mistakenly omitted.

---

##### Testing

- Add an exception to the `add_photo` view to force photo uploads to fail.
```diff
diff --git a/opentreemap/api/views.py b/opentreemap/api/views.py
index 69bed8cc..28d42b7a 100644
--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -274,6 +274,7 @@ def remove_current_tree_from_plot(request, instance, plot_id):
 
 
 def add_photo(request, instance, plot_id):
+    raise HttpBadRequestException()
     treephoto, __ = add_tree_photo_helper(request, instance, plot_id)
 
     return context_dict_for_photo(request, treephoto)
```
- Create a tree with a photo. Verify the new error message, that the photo is not displayed on either the edit page or map page, and that the map is not in "add" mode when returning from the edit page.
- Try adding a photo to an existing tree. Verify the error message and that the failed photo is not displayed on the edit page.

---

Connects to #85 