### PR TITLE
Support large text in stewardship items and choice field items

### DIFF
--- a/OpenTreeMap/src/OTM/Cells/OTMChoicesDetailCellRenderer.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMChoicesDetailCellRenderer.m
@@ -126,6 +126,9 @@
             [aController.navigationController pushViewController:tableController animated:YES];
         };
 
+        controller.tableView.estimatedRowHeight = 100.0;
+        controller.tableView.rowHeight = UITableViewAutomaticDimension;
+
         controller.tableView.delegate = (id<UITableViewDelegate>)self;
         controller.tableView.dataSource = (id<UITableViewDataSource>)self;
     }
@@ -235,6 +238,7 @@
                                       reuseIdentifier:kOTMEditChoicesDetailCellRendererCellId];
     }
 
+    aCell.textLabel.numberOfLines = 0;
     aCell.textLabel.text = [selectedDict objectForKey:@"display_value"];
     aCell.accessoryType = UITableViewCellAccessoryNone;
 

--- a/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.m
+++ b/OpenTreeMap/src/OTM/Cells/OTMUdfCollectionCell.m
@@ -516,6 +516,8 @@ NSString * const UdfDataChangedForStepNotification = @"UdfDataChangedForStepNoti
     self = [super init];
     if (self) {
         self.screenName = @"Custom Field Choices";  // for Google Analytics
+        self.tableView.estimatedRowHeight = 100.0;
+        self.tableView.rowHeight = UITableViewAutomaticDimension;
         self.key = key;
     }
     return self;


### PR DESCRIPTION
## Overview

When using the iOS "Larger Text" accessibility feature custom stewardship options and choice field options were being truncated rather than wrapping to a new line.  setting `numberOfLines` to zero and setting the row height on the parent table view to automatically increase the row height as needed resolves the issue.

Connects https://github.com/OpenTreeMap/otm-clients/issues/431 

### Demo

#### Before

![simulator screen shot - iphone 5 - 2018-07-25 at 10 41 40](https://user-images.githubusercontent.com/17363/43217906-c4ecf1f4-8ff7-11e8-848f-fe5932cf8874.png)![simulator screen shot - iphone 5 - 2018-07-25 at 10 48 08](https://user-images.githubusercontent.com/17363/43218094-4b4da7ca-8ff8-11e8-81a8-9da948fc2631.png)

#### After

![simulator screen shot - iphone 5 - 2018-07-25 at 10 44 07](https://user-images.githubusercontent.com/17363/43217918-ca918930-8ff7-11e8-914d-3de78cd74b40.png)![simulator screen shot - iphone 5 - 2018-07-25 at 10 47 04](https://user-images.githubusercontent.com/17363/43218111-553a8438-8ff8-11e8-97d7-1f9f409b7ac3.png)

## Testing Instructions

 * Create a new instance and add the tree stewardship options shown in the Demo screenshots and a custom choice field with a long option as shown in the Demo screenshots.
 * Connect to the instance from the iOS app, add a tree, and verify that the choice field options and stewardship options wrap correctly.
