### PR TITLE
Show the species edit field in instance defined order

### DIFF
--- a/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
+++ b/OpenTreeMap/src/OTM/Controllers/OTMTreeDetailViewController.m
@@ -310,10 +310,9 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
                      clickCallback:^(OTMDetailCellRenderer *renderer, NSMutableDictionary *cellData) {}];
     }
 
-    // Species and photo cells get added to the structure for editable fields.
-    NSArray *speciesAndPicSection = [NSArray arrayWithObjects:speciesRow, pictureRow, nil];
-    NSDictionary *speciesAndPicsDict = [[NSDictionary alloc] initWithObjects:[[NSArray alloc] initWithObjects:@"Tree Details", speciesAndPicSection, nil] forKeys:_dKeys];
-    [_editableFieldsWithSectionTitles addObject:speciesAndPicsDict];
+    NSArray *treeDetailsRows = [NSArray arrayWithObjects: pictureRow, nil];
+    NSDictionary *treeDetailsDict = [[NSDictionary alloc] initWithObjects:[[NSArray alloc] initWithObjects:@"Tree Details", treeDetailsRows, nil] forKeys:_dKeys];
+    [_editableFieldsWithSectionTitles addObject:treeDetailsDict];
 
     // Loop through cells and add editable cells to the editable fields structure.
     for (NSDictionary *dict in _fieldsWithSectionTitles) {
@@ -321,6 +320,10 @@ NSString * const UdfNewDataCreatedNotification = @"UdfNewDataCreatedNotification
         for (OTMDetailCellRenderer *cell in [dict valueForKey:@"cells"]) {
             if (cell.editCellRenderer != nil) {
                 [eCells addObject:cell.editCellRenderer];
+            } else if ([cell.dataKey isEqualToString:@"tree.species.common_name"]) {
+                // Species is a specal case. There are separate cells for common and scientific name in the detail view
+                // but there should only be one cell in the edit view.
+                [eCells addObject:speciesRow];
             }
         }
         if ([eCells count] > 0) {


### PR DESCRIPTION
## Overview

The species field is a special-case field and has previously been pinned to the top of the edit view along with photo field. This commit makes the species field respect the field sequence set on the management page.

Connects #365

### Demo

![Simulator Screen Shot - iPhone Xʀ - 2019-04-10 at 16 07 30](https://user-images.githubusercontent.com/17363/55919481-fedd6180-5baa-11e9-9ab6-ec1edc780bd8.png)


## Testing Instructions

 * Create an instance called `mobile-field-order`
 * Browse http://localhost:6060/mobile-field-order/management/field-configuration/, click the `Mobile` tab, and click `Edit`
 * Move the `Species` field down between `Tree Height` and `Date Planted` and click `Save`
 * Run the iOS app and log in with the same account used to create the `mobile-field-order` instance and switch to the `mobile-field-order` instance.
 * Add a tree. Verify that the species field is shown in the correct order. 
 * Add a second tree, then go back and edit the first tree. Verify that the species field is shown in the correct location.
